### PR TITLE
Improve date slicer stability and styling controls

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -115,6 +115,42 @@
           "type": {
             "bool": true
           }
+        },
+        "pillBackgroundColor": {
+          "displayName": "Pill background",
+          "type": {
+            "fill": {
+              "solid": {
+                "color": true
+              }
+            }
+          }
+        },
+        "pillBorderColor": {
+          "displayName": "Pill border",
+          "type": {
+            "fill": {
+              "solid": {
+                "color": true
+              }
+            }
+          }
+        },
+        "pillTextColor": {
+          "displayName": "Pill text",
+          "type": {
+            "fill": {
+              "solid": {
+                "color": true
+              }
+            }
+          }
+        },
+        "pillFontSize": {
+          "displayName": "Pill font size",
+          "type": {
+            "numeric": true
+          }
         }
       }
     },

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -23,9 +23,10 @@ export type CalendarProps = {
   locale: string;
   dataMin?: Date;
   dataMax?: Date;
+  weekStartsOn?: number;
 };
 
-export const Calendar: React.FC<CalendarProps> = ({ range, onRangeChange, locale, dataMin, dataMax }) => {
+export const Calendar: React.FC<CalendarProps> = ({ range, onRangeChange, locale, dataMin, dataMax, weekStartsOn }) => {
   const [visibleMonth, setVisibleMonth] = useState<Date>(startOfMonth(range.from));
   const [pendingStart, setPendingStart] = useState<Date | null>(null);
   const [focusDate, setFocusDate] = useState<Date>(() => range.from);
@@ -59,7 +60,9 @@ export const Calendar: React.FC<CalendarProps> = ({ range, onRangeChange, locale
     }
   }, [visibleMonth, monthTitleFormatter]);
 
-  const monthMatrix = useMemo(() => getMonthMatrix(visibleMonth, 1), [visibleMonth]);
+  const startDay = typeof weekStartsOn === "number" ? weekStartsOn : 1;
+
+  const monthMatrix = useMemo(() => getMonthMatrix(visibleMonth, startDay), [visibleMonth, startDay]);
 
   const today = useMemo(() => getToday(), []);
 

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -16,8 +16,13 @@ export type PopoverProps = {
   onPresetSelect: (presetId: string) => void;
   onRangeChange: (range: DateRange) => void;
   onApply: () => void;
-  onClear: () => void;
+  onClear?: () => void;
   onClose: () => void;
+  showQuickApply?: boolean;
+  onQuickApply?: () => void;
+  showClear?: boolean;
+  showPresetLabels?: boolean;
+  weekStartsOn?: number;
 };
 
 export const Popover: React.FC<PopoverProps> = ({
@@ -33,6 +38,11 @@ export const Popover: React.FC<PopoverProps> = ({
   onApply,
   onClear,
   onClose,
+  showQuickApply = false,
+  onQuickApply,
+  showClear = true,
+  showPresetLabels = true,
+  weekStartsOn,
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const previousActive = useRef<HTMLElement | null>(null);
@@ -102,6 +112,7 @@ export const Popover: React.FC<PopoverProps> = ({
             selectedPresetId={presetId}
             committedPresetId={committedPresetId}
             onPresetSelect={onPresetSelect}
+            showLabels={showPresetLabels}
           />
         </div>
         <div className="popover__calendar">
@@ -111,13 +122,21 @@ export const Popover: React.FC<PopoverProps> = ({
             locale={locale}
             dataMin={dataMin}
             dataMax={dataMax}
+            weekStartsOn={weekStartsOn}
           />
         </div>
       </div>
       <div className="popover__footer">
-        <button type="button" className="popover__ghost" onClick={onClear}>
-          Clear
-        </button>
+        {showQuickApply && onQuickApply ? (
+          <button type="button" className="popover__quick" onClick={onQuickApply}>
+            Today
+          </button>
+        ) : null}
+        {showClear && onClear ? (
+          <button type="button" className="popover__ghost" onClick={onClear}>
+            Clear
+          </button>
+        ) : null}
         <button type="button" className="popover__primary" onClick={onApply}>
           Apply
         </button>

--- a/src/components/Presets.tsx
+++ b/src/components/Presets.tsx
@@ -7,9 +7,16 @@ export type PresetsProps = {
   selectedPresetId: string;
   committedPresetId: string;
   onPresetSelect: (presetId: string) => void;
+  showLabels?: boolean;
 };
 
-export const Presets: React.FC<PresetsProps> = ({ presets, selectedPresetId, committedPresetId, onPresetSelect }) => {
+export const Presets: React.FC<PresetsProps> = ({
+  presets,
+  selectedPresetId,
+  committedPresetId,
+  onPresetSelect,
+  showLabels = true,
+}) => {
   return (
     <div className="presets" role="listbox" aria-label="Date presets">
       {presets.map((preset) => {
@@ -25,9 +32,15 @@ export const Presets: React.FC<PresetsProps> = ({ presets, selectedPresetId, com
             className={classes.join(" ")}
             role="option"
             aria-selected={isSelected}
+            aria-label={!showLabels ? preset.label : undefined}
             onClick={() => onPresetSelect(preset.id)}
           >
-            <span className="presets__label">{preset.label}</span>
+            <span
+              className={showLabels ? "presets__label" : "presets__label visually-hidden"}
+              aria-hidden={!showLabels}
+            >
+              {preset.label}
+            </span>
             {isCommitted && <span className="presets__badge">Applied</span>}
           </button>
         );

--- a/src/styles/date-range-filter.css
+++ b/src/styles/date-range-filter.css
@@ -9,7 +9,6 @@
   display: inline-flex;
   align-items: center;
   gap: var(--ds-spacing-2);
-  padding: 6px var(--ds-spacing-3);
   border-radius: 999px;
   border: 1px solid var(--ds-color-border);
   background-color: var(--ds-color-bg);
@@ -17,6 +16,16 @@
   color: var(--ds-color-text);
   cursor: pointer;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  line-height: 1.25;
+}
+
+.date-range-filter__pill--compact {
+  padding: 6px var(--ds-spacing-3);
+}
+
+.date-range-filter__pill--expanded {
+  padding: 10px var(--ds-spacing-4);
+  gap: var(--ds-spacing-3);
 }
 
 .date-range-filter__pill:hover {
@@ -31,7 +40,9 @@
 .date-range-filter__icon {
   width: 16px;
   height: 16px;
-  background: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 1.5C5 1.22386 4.77614 1 4.5 1C4.22386 1 4 1.22386 4 1.5V2H3.5C2.11929 2 1 3.11929 1 4.5V12.5C1 13.8807 2.11929 15 3.5 15H12.5C13.8807 15 15 13.8807 15 12.5V4.5C15 3.11929 13.8807 2 12.5 2H12V1.5C12 1.22386 11.7761 1 11.5 1C11.2239 1 11 1.22386 11 1.5V2H5V1.5Z' fill='%234B5563'/%3E%3Cpath d='M14 6H2V12.5C2 13.3284 2.67157 14 3.5 14H12.5C13.3284 14 14 13.3284 14 12.5V6Z' fill='%23FFFFFF'/%3E%3C/svg%3E") no-repeat center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .date-range-filter__label {
@@ -41,7 +52,16 @@
 .date-range-filter__chevron {
   width: 16px;
   height: 16px;
-  background: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.41 0.58L6 5.17L10.59 0.58L12 2L6 8L0 2L1.41 0.58Z' fill='%234B5563'/%3E%3C/svg%3E") no-repeat center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.date-range-filter__icon svg,
+.date-range-filter__chevron svg {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
 }
 
 .outside-frame-portal {

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -63,6 +63,21 @@
   cursor: pointer;
 }
 
+.popover__quick {
+  min-width: 96px;
+  border-radius: var(--ds-radius-small);
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  padding: 8px var(--ds-spacing-3);
+  font-size: var(--ds-font-size-medium);
+  cursor: pointer;
+  background-color: rgba(37, 99, 235, 0.1);
+  color: var(--ds-color-text);
+}
+
+.popover__quick:hover {
+  background-color: rgba(37, 99, 235, 0.18);
+}
+
 .popover__ghost {
   background-color: transparent;
   color: var(--ds-color-text);
@@ -111,7 +126,8 @@
   }
 
   .popover__ghost,
-  .popover__primary {
+  .popover__primary,
+  .popover__quick {
     width: 100%;
   }
 }

--- a/src/visual/visual.tsx
+++ b/src/visual/visual.tsx
@@ -14,12 +14,39 @@ type DataViewObjects = powerbi.DataViewObjects;
 type PersistedState = {
   range?: { from: string; to: string };
   presetId?: string;
+  raw?: string;
+};
+
+type DefaultsSettings = {
+  presetId?: string;
+  weekStartsOn?: number;
+  locale?: string;
+};
+
+type LimitsSettings = {
+  minDate?: Date;
+  maxDate?: Date;
+};
+
+type PillSettings = {
+  style?: "compact" | "expanded";
+  showPresetLabels?: boolean;
+  backgroundColor?: string;
+  borderColor?: string;
+  textColor?: string;
+  fontSize?: number;
+};
+
+type ButtonSettings = {
+  showQuickApply?: boolean;
+  showClear?: boolean;
 };
 
 type VisualSettings = {
-  defaultPresetId?: string;
-  minDate?: Date;
-  maxDate?: Date;
+  defaults: DefaultsSettings;
+  limits: LimitsSettings;
+  pill: PillSettings;
+  buttons: ButtonSettings;
   persistedState?: PersistedState;
 };
 
@@ -56,7 +83,7 @@ function parsePersistedState(value: unknown): PersistedState | undefined {
     if (!parsed || typeof parsed !== "object") {
       return undefined;
     }
-    return parsed;
+    return { ...parsed, raw: value };
   } catch (error) {
     console.warn("Failed to parse persisted state", error);
     return undefined;
@@ -67,16 +94,77 @@ function getObjects(dataView?: DataView): DataViewObjects | undefined {
   return dataView?.metadata?.objects ?? undefined;
 }
 
+function getNumericValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function getBooleanValue(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return undefined;
+}
+
+function getColorValue(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const fill = value as powerbi.Fill;
+  const solid = (fill as { solid?: { color?: string } }).solid;
+  const color = solid?.color;
+  return typeof color === "string" ? color : undefined;
+}
+
+function normalizeWeekStartsOn(value?: number): number | undefined {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return undefined;
+  }
+  const rounded = Math.round(value);
+  if (!Number.isFinite(rounded)) {
+    return undefined;
+  }
+  const normalized = ((rounded % 7) + 7) % 7;
+  return normalized;
+}
+
+function toFill(color?: string): powerbi.Fill | undefined {
+  return color ? { solid: { color } } : undefined;
+}
+
 function parseVisualSettings(dataView?: DataView): VisualSettings {
   const objects = getObjects(dataView);
   const defaults = objects?.defaults as powerbi.DataViewObject | undefined;
   const limits = objects?.limits as powerbi.DataViewObject | undefined;
   const state = objects?.state as powerbi.DataViewObject | undefined;
 
+  const pill = objects?.pill as powerbi.DataViewObject | undefined;
+  const buttons = objects?.buttons as powerbi.DataViewObject | undefined;
+
   return {
-    defaultPresetId: (defaults?.defaultPreset as string | undefined) ?? undefined,
-    minDate: coerceDate(limits?.minDate),
-    maxDate: coerceDate(limits?.maxDate),
+    defaults: {
+      presetId: (defaults?.defaultPreset as string | undefined) ?? undefined,
+      weekStartsOn: getNumericValue(defaults?.weekStartsOn),
+      locale: typeof defaults?.locale === "string" ? defaults.locale : undefined,
+    },
+    limits: {
+      minDate: coerceDate(limits?.minDate),
+      maxDate: coerceDate(limits?.maxDate),
+    },
+    pill: {
+      style: (pill?.pillStyle as PillSettings["style"]) ?? undefined,
+      showPresetLabels: getBooleanValue(pill?.showPresetLabels),
+      backgroundColor: getColorValue(pill?.pillBackgroundColor),
+      borderColor: getColorValue(pill?.pillBorderColor),
+      textColor: getColorValue(pill?.pillTextColor),
+      fontSize: getNumericValue(pill?.pillFontSize),
+    },
+    buttons: {
+      showQuickApply: getBooleanValue(buttons?.showQuickApply),
+      showClear: getBooleanValue(buttons?.showClear),
+    },
     persistedState: parsePersistedState(state?.payload),
   };
 }
@@ -165,10 +253,20 @@ function toPersistedPayload(range: DateRange, presetId: string): string {
 }
 
 function rangesEqual(a: DateRange | undefined, b: DateRange | undefined): boolean {
+  if (!a && !b) {
+    return true;
+  }
   if (!a || !b) {
     return false;
   }
   return toISODate(a.from) === toISODate(b.from) && toISODate(a.to) === toISODate(b.to);
+}
+
+function toRangeKey(range: DateRange | undefined): string | undefined {
+  if (!range) {
+    return undefined;
+  }
+  return `${toISODate(range.from)}:${toISODate(range.to)}`;
 }
 
 export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVisual {
@@ -186,6 +284,19 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
 
   private currentPresetId?: string;
 
+  private settings: VisualSettings = {
+    defaults: {},
+    limits: {},
+    pill: {},
+    buttons: {},
+  };
+
+  private lastRenderKey?: string;
+
+  private lastAppliedFilterKey?: string;
+
+  private lastPersistedPayload?: string;
+
   constructor(options?: VisualConstructorOptions) {
     if (!options) {
       throw new Error("Visual constructor options are required.");
@@ -202,8 +313,11 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
     this.dataView = options.dataViews?.[0];
     this.columnTarget = findColumnTarget(this.dataView);
     const settings = parseVisualSettings(this.dataView);
+    this.settings = settings;
     const bounds = getDataBounds(this.dataView);
     const appliedRange = findExistingFilterRange(options, this.columnTarget);
+
+    this.lastPersistedPayload = settings.persistedState?.raw ?? undefined;
 
     const persistedRange = settings.persistedState?.range;
     const persisted = (() => {
@@ -212,18 +326,64 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
       }
       const from = coerceDate(persistedRange.from);
       const to = coerceDate(persistedRange.to);
-      return from && to ? normalizeRange(from, to) : undefined;
+      if (!from || !to) {
+        return undefined;
+      }
+      return normalizeRange(from, to);
     })();
+
+    const limitedMin = settings.limits.minDate ?? bounds.min;
+    const limitedMax = settings.limits.maxDate ?? bounds.max;
 
     const initialRange = appliedRange ?? persisted;
 
     const defaultRange = initialRange
-      ? ensureWithinRange(initialRange, settings.minDate ?? bounds.min, settings.maxDate ?? bounds.max)
+      ? ensureWithinRange(initialRange, limitedMin, limitedMax)
       : undefined;
 
     const defaultPresetId = appliedRange
       ? undefined
-      : settings.persistedState?.presetId ?? settings.defaultPresetId ?? undefined;
+      : settings.persistedState?.presetId ?? settings.defaults.presetId ?? undefined;
+
+    const rangeForComponent = defaultRange ?? initialRange;
+    const appliedKey = toRangeKey(appliedRange);
+    if (appliedRange) {
+      this.lastAppliedFilterKey = appliedKey;
+      if (!rangesEqual(this.currentRange, appliedRange)) {
+        this.currentRange = appliedRange;
+        this.currentPresetId = undefined;
+      }
+    } else {
+      this.lastAppliedFilterKey = undefined;
+    }
+
+    const renderKey = JSON.stringify({
+      width: options.viewport?.width ?? 0,
+      height: options.viewport?.height ?? 0,
+      range: rangeForComponent ? [rangeForComponent.from.getTime(), rangeForComponent.to.getTime()] : null,
+      preset: defaultPresetId ?? null,
+      bounds: [limitedMin?.getTime() ?? null, limitedMax?.getTime() ?? null],
+      locale: settings.defaults.locale ?? null,
+      weekStartsOn: normalizeWeekStartsOn(settings.defaults.weekStartsOn) ?? null,
+      pill: {
+        style: settings.pill.style ?? null,
+        showPresetLabels: settings.pill.showPresetLabels ?? null,
+        backgroundColor: settings.pill.backgroundColor ?? null,
+        borderColor: settings.pill.borderColor ?? null,
+        textColor: settings.pill.textColor ?? null,
+        fontSize: settings.pill.fontSize ?? null,
+      },
+      buttons: {
+        showQuickApply: settings.buttons.showQuickApply ?? null,
+        showClear: settings.buttons.showClear ?? null,
+      },
+    });
+
+    const isResizeOnly = (options.type & powerbi.VisualUpdateType.Resize) === options.type;
+    if (!isResizeOnly && this.lastRenderKey === renderKey) {
+      return;
+    }
+    this.lastRenderKey = renderKey;
 
     const handleChange = (range: DateRange, presetId: string) => {
       if (rangesEqual(this.currentRange, range) && this.currentPresetId === presetId) {
@@ -235,18 +395,41 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
       this.persistState(range, presetId);
     };
 
+    const weekStartsOn = normalizeWeekStartsOn(settings.defaults.weekStartsOn) ?? 1;
+    const locale = settings.defaults.locale?.trim() ? settings.defaults.locale : undefined;
+    const showPresetLabels = settings.pill.showPresetLabels ?? true;
+    const showClear = settings.buttons.showClear ?? true;
+    const pillFontSize =
+      typeof settings.pill.fontSize === "number" && settings.pill.fontSize > 0
+        ? settings.pill.fontSize
+        : undefined;
+
     this.reactRoot.render(
       <DateRangeFilter
         presets={PRESETS}
-        dataMin={settings.minDate ?? bounds.min}
-        dataMax={settings.maxDate ?? bounds.max}
+        dataMin={limitedMin}
+        dataMax={limitedMax}
         defaultPresetId={defaultPresetId}
         defaultRange={defaultRange}
+        localeOverride={locale}
+        weekStartsOn={weekStartsOn}
+        pillStyle={settings.pill.style}
+        pillColors={{
+          background: settings.pill.backgroundColor,
+          border: settings.pill.borderColor,
+          text: settings.pill.textColor,
+        }}
+        pillFontSize={pillFontSize}
+        showPresetLabels={showPresetLabels}
+        showQuickApply={settings.buttons.showQuickApply ?? false}
+        showClear={showClear}
         onChange={handleChange}
       />,
     );
 
-    if ((options.type & powerbi.VisualUpdateType.Resize) === 0 && defaultRange && !rangesEqual(this.currentRange, defaultRange)) {
+    const shouldApplyDefault =
+      !appliedRange && defaultRange && !rangesEqual(this.currentRange, defaultRange);
+    if (!isResizeOnly && shouldApplyDefault) {
       this.currentRange = defaultRange;
       this.currentPresetId = defaultPresetId;
       this.applyRangeFilter(defaultRange);
@@ -254,18 +437,71 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
   }
 
   public enumerateObjectInstances(options: powerbi.EnumerateVisualObjectInstancesOptions): VisualObjectInstance[] {
-    if (options.objectName === "defaults") {
-      return [
-        {
-          objectName: "defaults",
-          properties: {
-            defaultPreset: this.currentPresetId ?? "last7",
+    const selector = undefined as unknown as powerbi.data.Selector;
+    switch (options.objectName) {
+      case "defaults":
+        return [
+          {
+            objectName: "defaults",
+            properties: {
+              defaultPreset: this.currentPresetId ?? this.settings.defaults.presetId ?? "last7",
+              weekStartsOn: normalizeWeekStartsOn(this.settings.defaults.weekStartsOn) ?? 1,
+              locale: this.settings.defaults.locale ?? "",
+            },
+            selector,
           },
-          selector: undefined as unknown as powerbi.data.Selector,
-        },
-      ];
+        ];
+      case "limits":
+        return [
+          {
+            objectName: "limits",
+            properties: {
+              minDate: this.settings.limits.minDate ? toISODate(this.settings.limits.minDate) : "",
+              maxDate: this.settings.limits.maxDate ? toISODate(this.settings.limits.maxDate) : "",
+            },
+            selector,
+          },
+        ];
+      case "pill": {
+        const properties: powerbi.DataViewObject = {
+          pillStyle: this.settings.pill.style ?? "compact",
+          showPresetLabels: this.settings.pill.showPresetLabels ?? true,
+          pillFontSize: this.settings.pill.fontSize ?? 12,
+        };
+        const background = toFill(this.settings.pill.backgroundColor);
+        if (background) {
+          properties.pillBackgroundColor = background;
+        }
+        const border = toFill(this.settings.pill.borderColor);
+        if (border) {
+          properties.pillBorderColor = border;
+        }
+        const text = toFill(this.settings.pill.textColor);
+        if (text) {
+          properties.pillTextColor = text;
+        }
+        return [
+          {
+            objectName: "pill",
+            properties,
+            selector,
+          },
+        ];
+      }
+      case "buttons":
+        return [
+          {
+            objectName: "buttons",
+            properties: {
+              showQuickApply: this.settings.buttons.showQuickApply ?? false,
+              showClear: this.settings.buttons.showClear ?? true,
+            },
+            selector,
+          },
+        ];
+      default:
+        return [];
     }
-    return [];
   }
 
   public destroy(): void {
@@ -277,6 +513,13 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
     if (!this.columnTarget) {
       return;
     }
+    const key = toRangeKey(range);
+    if (this.lastAppliedFilterKey && key && this.lastAppliedFilterKey === key) {
+      return;
+    }
+    if (key) {
+      this.lastAppliedFilterKey = key;
+    }
 
     const filter = new models.AdvancedFilter(this.columnTarget, "And", [
       { operator: "GreaterThanOrEqual", value: toISODate(range.from) },
@@ -287,13 +530,18 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
   }
 
   private persistState(range: DateRange, presetId: string): void {
+    const payload = toPersistedPayload(range, presetId);
+    if (this.lastPersistedPayload === payload) {
+      return;
+    }
+    this.lastPersistedPayload = payload;
     this.host.persistProperties({
       merge: [
         {
           objectName: "state",
           selector: undefined as unknown as powerbi.data.Selector,
           properties: {
-            payload: toPersistedPayload(range, presetId),
+            payload,
           },
         },
         {
@@ -305,6 +553,12 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
         },
       ],
     });
+    this.settings.persistedState = {
+      range: { from: toISODate(range.from), to: toISODate(range.to) },
+      presetId,
+      raw: payload,
+    };
+    this.settings.defaults.presetId = presetId;
   }
 }
 


### PR DESCRIPTION
## Summary
- add change detection and settings parsing in the visual to avoid redundant host updates and expose new style toggles
- update the date range filter UI with quick apply actions, configurable pill styling, and respect week start/locale settings
- throttle portal geometry updates and refresh capabilities to include new color and font options

## Testing
- npm run build
- npm run lint
- npm test -- --runTestsByPath test/date-range-filter.spec.tsx

------
https://chatgpt.com/codex/tasks/task_b_68eb534e38488321b098af168e0df21b