### PR TITLE
Fix pbiviz packaging dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jest": "29.7.0",
         "jest-environment-jsdom": "30.2.0",
         "loader-runner": "4.3.1",
+        "neo-async": "2.6.2",
         "patch-package": "8.0.1",
         "powerbi-visuals-api": "5.11.0",
         "powerbi-visuals-tools": "6.2.0",
@@ -8046,6 +8047,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-forge": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jest": "29.7.0",
     "jest-environment-jsdom": "30.2.0",
     "loader-runner": "4.3.1",
+    "neo-async": "2.6.2",
     "patch-package": "8.0.1",
     "powerbi-visuals-api": "5.11.0",
     "powerbi-visuals-tools": "6.2.0",

--- a/patches/eslint-scope+7.2.2.patch
+++ b/patches/eslint-scope+7.2.2.patch
@@ -10,3 +10,19 @@ index 0000000..8e7aadb
 +
 +module.exports = Referencer;
 +module.exports.default = module.exports;
+diff --git a/node_modules/eslint-scope/package.json b/node_modules/eslint-scope/package.json
+index 4d988f1..9ecb166 100644
+--- a/node_modules/eslint-scope/package.json
++++ b/node_modules/eslint-scope/package.json
+@@
+   "exports": {
+     ".": {
+       "import": "./lib/index.js",
+       "require": "./dist/eslint-scope.cjs"
+     },
++    "./lib/referencer": {
++      "import": "./lib/referencer.cjs",
++      "require": "./lib/referencer.cjs"
++    },
+     "./package.json": "./package.json"
+   },


### PR DESCRIPTION
## Summary
- add the missing neo-async dependency required by webpack during pbiviz packaging
- update the eslint-scope patch to export the referencer helper so pbiviz linting can run

## Testing
- npm run package:visual

------
https://chatgpt.com/codex/tasks/task_b_68edad5a18408321822fc00bc44c8868