### PR TITLE
Enable configurable pill width and expand date labels

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -151,6 +151,12 @@
           "type": {
             "numeric": true
           }
+        },
+        "pillMinWidth": {
+          "displayName": "Pill minimum width",
+          "type": {
+            "numeric": true
+          }
         }
       }
     },

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -43,11 +43,20 @@ export const Calendar: React.FC<CalendarProps> = ({ range, onRangeChange, locale
     [locale],
   );
 
+  const fromTime = range.from.getTime();
+  const toTime = range.to.getTime();
+  const rangeRef = useRef(range);
+  rangeRef.current = range;
+
   useEffect(() => {
-    if (!isSameMonth(range.from, visibleMonth) && !isSameMonth(range.to, visibleMonth)) {
-      setVisibleMonth(startOfMonth(range.from));
-    }
-  }, [range, visibleMonth]);
+    setVisibleMonth((current) => {
+      const { from, to } = rangeRef.current;
+      if (isSameMonth(from, current) || isSameMonth(to, current)) {
+        return current;
+      }
+      return startOfMonth(from);
+    });
+  }, [fromTime, toTime]);
 
   useEffect(() => {
     setFocusDate(range.from);

--- a/src/components/DateRangeFilter.tsx
+++ b/src/components/DateRangeFilter.tsx
@@ -59,6 +59,7 @@ type DateRangeFilterProps = {
   pillStyle?: "compact" | "expanded";
   pillColors?: { background?: string; border?: string; text?: string };
   pillFontSize?: number;
+  pillMinWidth?: number;
   showPresetLabels?: boolean;
   showQuickApply?: boolean;
   showClear?: boolean;
@@ -222,6 +223,7 @@ export const DateRangeFilter: React.FC<DateRangeFilterProps> = ({
   pillStyle = "compact",
   pillColors,
   pillFontSize,
+  pillMinWidth,
   showPresetLabels = true,
   showQuickApply = false,
   showClear = true,
@@ -394,6 +396,7 @@ export const DateRangeFilter: React.FC<DateRangeFilterProps> = ({
           borderColor: pillColors?.border,
           color: pillColors?.text,
           fontSize: pillFontSize ? `${pillFontSize}px` : undefined,
+          minWidth: pillMinWidth ? `${pillMinWidth}px` : undefined,
         }}
       >
         <span className="date-range-filter__icon" aria-hidden="true">

--- a/src/date/utils.ts
+++ b/src/date/utils.ts
@@ -152,26 +152,15 @@ export function fromISODate(value: string): Date | null {
 
 export function formatRange(from: Date, to: Date, locale: string): string {
   const formatter = new Intl.DateTimeFormat(locale, {
-    month: "short",
+    month: "long",
     day: "numeric",
-    year: from.getFullYear() !== to.getFullYear() ? "numeric" : undefined,
+    year: "numeric",
   });
 
-  const sameMonth = isSameMonth(from, to);
-  const sameYear = from.getFullYear() === to.getFullYear();
+  const fromLabel = formatter.format(from);
+  const toLabel = formatter.format(to);
 
-  if (sameMonth && sameYear) {
-    const monthFormatter = new Intl.DateTimeFormat(locale, {
-      month: "short",
-    });
-    return `${monthFormatter.format(from)} ${from.getDate()} – ${to.getDate()}, ${from.getFullYear()}`;
-  }
-
-  if (sameYear) {
-    return `${formatter.format(from)} – ${formatter.format(to)}, ${from.getFullYear()}`;
-  }
-
-  return `${formatter.format(from)} – ${formatter.format(to)}`;
+  return `${fromLabel} – ${toLabel}`;
 }
 
 export function getToday(): Date {

--- a/src/styles/date-range-filter.css
+++ b/src/styles/date-range-filter.css
@@ -17,6 +17,7 @@
   cursor: pointer;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
   line-height: 1.25;
+  min-width: 260px;
 }
 
 .date-range-filter__pill--compact {

--- a/src/visual/formattingSettings.ts
+++ b/src/visual/formattingSettings.ts
@@ -119,6 +119,16 @@ export class PillCardSettings extends SimpleCard {
     },
   });
 
+  public pillMinWidth = new NumUpDown({
+    name: "pillMinWidth",
+    displayName: "Pill minimum width",
+    value: 260,
+    options: {
+      minValue: { value: 120, type: powerbi.visuals.ValidatorType.Min },
+      maxValue: { value: 640, type: powerbi.visuals.ValidatorType.Max },
+    },
+  });
+
   public slices = [
     this.pillStyle,
     this.showPresetLabels,
@@ -126,6 +136,7 @@ export class PillCardSettings extends SimpleCard {
     this.pillBorderColor,
     this.pillTextColor,
     this.pillFontSize,
+    this.pillMinWidth,
   ];
 }
 

--- a/test/date-range-filter.spec.tsx
+++ b/test/date-range-filter.spec.tsx
@@ -1,4 +1,5 @@
-import React, { act } from "react";
+import React from "react";
+import { act } from "react-dom/test-utils";
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 import { createRoot, Root } from "react-dom/client";

--- a/test/date-utils.spec.ts
+++ b/test/date-utils.spec.ts
@@ -28,6 +28,6 @@ describe("date utilities", () => {
     const from = new Date(Date.UTC(2022, 1, 17));
     const to = new Date(Date.UTC(2022, 1, 21));
     const label = formatRange(from, to, "en-US");
-    expect(label).toContain("Feb");
+    expect(label).toBe("February 17, 2022 – February 21, 2022");
   });
 });


### PR DESCRIPTION
## Summary
- expand the range formatter so the pill always shows full month/day/year strings and widen the base pill styling
- add a configurable pill minimum width option in the formatting pane and thread it through the React visual
- update the unit tests to use the correct React act helper and assert the long-form label so the suite passes

## Testing
- npm test -- --runInBand
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68edbeb9d4e48321957f73a842297c02