### PR TITLE
Enable cross-filtering and auto-derived date limits

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -30,6 +30,16 @@
     }
   ],
   "objects": {
+    "general": {
+      "displayName": "General",
+      "properties": {
+        "filter": {
+          "type": {
+            "filter": {}
+          }
+        }
+      }
+    },
     "defaults": {
       "displayName": "Defaults",
       "properties": {
@@ -77,23 +87,6 @@
           "displayName": "Comparison on by default",
           "type": {
             "bool": true
-          }
-        }
-      }
-    },
-    "limits": {
-      "displayName": "Limits",
-      "properties": {
-        "minDate": {
-          "displayName": "Minimum date",
-          "type": {
-            "text": true
-          }
-        },
-        "maxDate": {
-          "displayName": "Maximum date",
-          "type": {
-            "text": true
           }
         }
       }

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,0 +1,59 @@
+import * as models from "powerbi-models";
+
+export function parseTargetFromQueryName(
+  queryName?: string,
+): models.IFilterColumnTarget | undefined {
+  if (!queryName) {
+    return undefined;
+  }
+
+  const bracketMatch = queryName.match(/^(.*)\[([^\]]+)\]$/);
+  if (bracketMatch) {
+    const [, table, column] = bracketMatch;
+    if (table && column) {
+      return { table, column };
+    }
+  }
+
+  const dotSegments = queryName.split(".");
+  if (dotSegments.length >= 2) {
+    const column = dotSegments.pop();
+    const table = dotSegments.join(".");
+    if (table && column) {
+      return { table, column };
+    }
+  }
+
+  return undefined;
+}
+
+export function toDateOnlyIso(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function extentFromValues(values: unknown[]): { min?: Date; max?: Date } {
+  if (!values || values.length === 0) {
+    return {};
+  }
+
+  const dates = values
+    .map((value) => {
+      if (value instanceof Date) {
+        return new Date(value.getTime());
+      }
+      if (value == null) {
+        return undefined;
+      }
+      const parsed = new Date(value as any);
+      return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+    })
+    .filter((value): value is Date => !!value && !Number.isNaN(value.getTime()));
+
+  if (dates.length === 0) {
+    return {};
+  }
+
+  dates.sort((a, b) => a.getTime() - b.getTime());
+
+  return { min: dates[0], max: dates[dates.length - 1] };
+}

--- a/src/visual/formattingSettings.ts
+++ b/src/visual/formattingSettings.ts
@@ -53,27 +53,6 @@ export class DefaultsCardSettings extends SimpleCard {
   public slices = [this.defaultPreset, this.weekStartsOn, this.locale];
 }
 
-export class LimitsCardSettings extends SimpleCard {
-  public name = "limits";
-  public displayName = "Limits";
-
-  public minDate = new TextInput({
-    name: "minDate",
-    displayName: "Minimum date",
-    value: "",
-    placeholder: "YYYY-MM-DD",
-  });
-
-  public maxDate = new TextInput({
-    name: "maxDate",
-    displayName: "Maximum date",
-    value: "",
-    placeholder: "YYYY-MM-DD",
-  });
-
-  public slices = [this.minDate, this.maxDate];
-}
-
 export class PillCardSettings extends SimpleCard {
   public name = "pill";
   public displayName = "Pill";
@@ -161,11 +140,10 @@ export class ButtonsCardSettings extends SimpleCard {
 
 export class PresetDateSlicerFormattingSettingsModel extends Model {
   public defaults = new DefaultsCardSettings();
-  public limits = new LimitsCardSettings();
   public pill = new PillCardSettings();
   public buttons = new ButtonsCardSettings();
 
-  public cards = [this.defaults, this.limits, this.pill, this.buttons];
+  public cards = [this.defaults, this.pill, this.buttons];
 }
 
 export type PresetDateSlicerFormattingSettings = PresetDateSlicerFormattingSettingsModel;


### PR DESCRIPTION
## Summary
- add general filter capability and remove manual min/max formatting properties
- derive date bounds from the bound field and apply advanced filters via host.applyJsonFilter
- introduce shared helpers for filter target parsing and date extents used by the visual

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ede5eef61c83218f271b3430eadb0f