### PR TITLE
Fix capabilities schema violations

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -11,8 +11,7 @@
       "name": "date",
       "kind": "Grouping",
       "displayName": "Date",
-      "displayNameKey": "role_date_displayName",
-      "preferredTypes": { "dateTime": true }
+      "displayNameKey": "role_date_displayName"
     }
   ],
 
@@ -186,7 +185,7 @@
         "payload": {
           "displayNameKey": "format_state_payload",
           "displayName": "Selection state",
-          "type": { "text": true, "filterState": true }
+          "type": { "text": true }
         }
       }
     }


### PR DESCRIPTION
## Summary
- remove the unsupported preferredTypes declaration from the date data role to satisfy the Power BI schema
- align the state payload property type with the schema by limiting it to text

## Testing
- npm run package:visual

------
https://chatgpt.com/codex/tasks/task_b_68eeffc025c88321a1dbccf807b0699d