### PR TITLE
Fix JSON syntax error in capabilities definition

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -12,7 +12,7 @@
       "name": "date",
       "kind": "Grouping",
       "displayName": "Date",
-      "displayNameKey": "role_date_displayName",
+      "displayNameKey": "role_date_displayName"
     }
   ],
 


### PR DESCRIPTION
## Summary
- remove the trailing comma from the date role displayNameKey entry so capabilities.json is valid JSON

## Testing
- npm run package:visual

------
https://chatgpt.com/codex/tasks/task_b_68ef0f600f548321b998a5e09d089d13