### PR TITLE
Set pill defaults and improve format pane localization

### DIFF
--- a/artifacts/formatting-model.json
+++ b/artifacts/formatting-model.json
@@ -8,48 +8,69 @@
           "items": [
             {
               "value": "today",
-              "displayNameKey": "preset_today"
+              "displayNameKey": "preset_today",
+              "displayName": "Today"
             },
             {
               "value": "yesterday",
-              "displayNameKey": "preset_yesterday"
+              "displayNameKey": "preset_yesterday",
+              "displayName": "Yesterday"
             },
             {
               "value": "last7",
-              "displayNameKey": "preset_last7"
+              "displayNameKey": "preset_last7",
+              "displayName": "Last 7 days"
             },
             {
               "value": "last30",
-              "displayNameKey": "preset_last30"
+              "displayNameKey": "preset_last30",
+              "displayName": "Last 30 days"
+            },
+            {
+              "value": "lastWeek",
+              "displayNameKey": "preset_lastWeek",
+              "displayName": "Last week"
             },
             {
               "value": "thisMonth",
-              "displayNameKey": "preset_thisMonth"
+              "displayNameKey": "preset_thisMonth",
+              "displayName": "This month"
             },
             {
               "value": "lastMonth",
-              "displayNameKey": "preset_lastMonth"
+              "displayNameKey": "preset_lastMonth",
+              "displayName": "Last month"
+            },
+            {
+              "value": "mtd",
+              "displayNameKey": "preset_mtd",
+              "displayName": "Month to date"
             },
             {
               "value": "qtd",
-              "displayNameKey": "preset_qtd"
+              "displayNameKey": "preset_qtd",
+              "displayName": "Quarter to date"
             },
             {
               "value": "ytd",
-              "displayNameKey": "preset_ytd"
+              "displayNameKey": "preset_ytd",
+              "displayName": "Year to date"
             },
             {
               "value": "lastYear",
-              "displayNameKey": "preset_lastYear"
+              "displayNameKey": "preset_lastYear",
+              "displayName": "Last year"
             },
             {
               "value": "custom",
-              "displayNameKey": "preset_custom"
+              "displayNameKey": "preset_custom",
+              "displayName": "Custom"
             }
           ],
           "value": {
             "value": "last30",
-            "displayNameKey": "preset_last30"
+            "displayNameKey": "preset_last30",
+            "displayName": "Last 30 days"
           }
         },
         {
@@ -58,36 +79,44 @@
           "items": [
             {
               "value": "0",
-              "displayNameKey": "weekday_sun"
+              "displayNameKey": "weekday_sun",
+              "displayName": "Sunday"
             },
             {
               "value": "1",
-              "displayNameKey": "weekday_mon"
+              "displayNameKey": "weekday_mon",
+              "displayName": "Monday"
             },
             {
               "value": "2",
-              "displayNameKey": "weekday_tue"
+              "displayNameKey": "weekday_tue",
+              "displayName": "Tuesday"
             },
             {
               "value": "3",
-              "displayNameKey": "weekday_wed"
+              "displayNameKey": "weekday_wed",
+              "displayName": "Wednesday"
             },
             {
               "value": "4",
-              "displayNameKey": "weekday_thu"
+              "displayNameKey": "weekday_thu",
+              "displayName": "Thursday"
             },
             {
               "value": "5",
-              "displayNameKey": "weekday_fri"
+              "displayNameKey": "weekday_fri",
+              "displayName": "Friday"
             },
             {
               "value": "6",
-              "displayNameKey": "weekday_sat"
+              "displayNameKey": "weekday_sat",
+              "displayName": "Saturday"
             }
           ],
           "value": {
             "value": "1",
-            "displayNameKey": "weekday_mon"
+            "displayNameKey": "weekday_mon",
+            "displayName": "Monday"
           }
         },
         {
@@ -96,97 +125,129 @@
           "items": [
             {
               "value": "en-AU",
-              "displayNameKey": "locale_en_AU"
+              "displayNameKey": "locale_en_AU",
+              "displayName": "English (Australia)"
             },
             {
               "value": "en-US",
-              "displayNameKey": "locale_en_US"
+              "displayNameKey": "locale_en_US",
+              "displayName": "English (United States)"
             },
             {
               "value": "en-GB",
-              "displayNameKey": "locale_en_GB"
+              "displayNameKey": "locale_en_GB",
+              "displayName": "English (United Kingdom)"
             },
             {
               "value": "fr-FR",
-              "displayNameKey": "locale_fr_FR"
+              "displayNameKey": "locale_fr_FR",
+              "displayName": "French (France)"
             },
             {
               "value": "de-DE",
-              "displayNameKey": "locale_de_DE"
+              "displayNameKey": "locale_de_DE",
+              "displayName": "German (Germany)"
             },
             {
               "value": "es-ES",
-              "displayNameKey": "locale_es_ES"
+              "displayNameKey": "locale_es_ES",
+              "displayName": "Spanish (Spain)"
             },
             {
               "value": "it-IT",
-              "displayNameKey": "locale_it_IT"
+              "displayNameKey": "locale_it_IT",
+              "displayName": "Italian (Italy)"
             },
             {
               "value": "ja-JP",
-              "displayNameKey": "locale_ja_JP"
+              "displayNameKey": "locale_ja_JP",
+              "displayName": "Japanese (Japan)"
             },
             {
               "value": "zh-CN",
-              "displayNameKey": "locale_zh_CN"
+              "displayNameKey": "locale_zh_CN",
+              "displayName": "Chinese (China)"
             }
           ],
           "value": {
             "value": "en-US",
-            "displayNameKey": "locale_en_US"
+            "displayNameKey": "locale_en_US",
+            "displayName": "English (United States)"
           }
         }
       ],
       "name": "defaults",
       "displayNameKey": "format_defaults_displayName",
+      "displayName": "Defaults",
       "defaultPreset": {
         "name": "defaultPreset",
         "displayNameKey": "format_defaults_defaultPreset",
         "items": [
           {
             "value": "today",
-            "displayNameKey": "preset_today"
+            "displayNameKey": "preset_today",
+            "displayName": "Today"
           },
           {
             "value": "yesterday",
-            "displayNameKey": "preset_yesterday"
+            "displayNameKey": "preset_yesterday",
+            "displayName": "Yesterday"
           },
           {
             "value": "last7",
-            "displayNameKey": "preset_last7"
+            "displayNameKey": "preset_last7",
+            "displayName": "Last 7 days"
           },
           {
             "value": "last30",
-            "displayNameKey": "preset_last30"
+            "displayNameKey": "preset_last30",
+            "displayName": "Last 30 days"
+          },
+          {
+            "value": "lastWeek",
+            "displayNameKey": "preset_lastWeek",
+            "displayName": "Last week"
           },
           {
             "value": "thisMonth",
-            "displayNameKey": "preset_thisMonth"
+            "displayNameKey": "preset_thisMonth",
+            "displayName": "This month"
           },
           {
             "value": "lastMonth",
-            "displayNameKey": "preset_lastMonth"
+            "displayNameKey": "preset_lastMonth",
+            "displayName": "Last month"
+          },
+          {
+            "value": "mtd",
+            "displayNameKey": "preset_mtd",
+            "displayName": "Month to date"
           },
           {
             "value": "qtd",
-            "displayNameKey": "preset_qtd"
+            "displayNameKey": "preset_qtd",
+            "displayName": "Quarter to date"
           },
           {
             "value": "ytd",
-            "displayNameKey": "preset_ytd"
+            "displayNameKey": "preset_ytd",
+            "displayName": "Year to date"
           },
           {
             "value": "lastYear",
-            "displayNameKey": "preset_lastYear"
+            "displayNameKey": "preset_lastYear",
+            "displayName": "Last year"
           },
           {
             "value": "custom",
-            "displayNameKey": "preset_custom"
+            "displayNameKey": "preset_custom",
+            "displayName": "Custom"
           }
         ],
         "value": {
           "value": "last30",
-          "displayNameKey": "preset_last30"
+          "displayNameKey": "preset_last30",
+          "displayName": "Last 30 days"
         }
       },
       "weekStartsOn": {
@@ -195,36 +256,44 @@
         "items": [
           {
             "value": "0",
-            "displayNameKey": "weekday_sun"
+            "displayNameKey": "weekday_sun",
+            "displayName": "Sunday"
           },
           {
             "value": "1",
-            "displayNameKey": "weekday_mon"
+            "displayNameKey": "weekday_mon",
+            "displayName": "Monday"
           },
           {
             "value": "2",
-            "displayNameKey": "weekday_tue"
+            "displayNameKey": "weekday_tue",
+            "displayName": "Tuesday"
           },
           {
             "value": "3",
-            "displayNameKey": "weekday_wed"
+            "displayNameKey": "weekday_wed",
+            "displayName": "Wednesday"
           },
           {
             "value": "4",
-            "displayNameKey": "weekday_thu"
+            "displayNameKey": "weekday_thu",
+            "displayName": "Thursday"
           },
           {
             "value": "5",
-            "displayNameKey": "weekday_fri"
+            "displayNameKey": "weekday_fri",
+            "displayName": "Friday"
           },
           {
             "value": "6",
-            "displayNameKey": "weekday_sat"
+            "displayNameKey": "weekday_sat",
+            "displayName": "Saturday"
           }
         ],
         "value": {
           "value": "1",
-          "displayNameKey": "weekday_mon"
+          "displayNameKey": "weekday_mon",
+          "displayName": "Monday"
         }
       },
       "locale": {
@@ -233,44 +302,54 @@
         "items": [
           {
             "value": "en-AU",
-            "displayNameKey": "locale_en_AU"
+            "displayNameKey": "locale_en_AU",
+            "displayName": "English (Australia)"
           },
           {
             "value": "en-US",
-            "displayNameKey": "locale_en_US"
+            "displayNameKey": "locale_en_US",
+            "displayName": "English (United States)"
           },
           {
             "value": "en-GB",
-            "displayNameKey": "locale_en_GB"
+            "displayNameKey": "locale_en_GB",
+            "displayName": "English (United Kingdom)"
           },
           {
             "value": "fr-FR",
-            "displayNameKey": "locale_fr_FR"
+            "displayNameKey": "locale_fr_FR",
+            "displayName": "French (France)"
           },
           {
             "value": "de-DE",
-            "displayNameKey": "locale_de_DE"
+            "displayNameKey": "locale_de_DE",
+            "displayName": "German (Germany)"
           },
           {
             "value": "es-ES",
-            "displayNameKey": "locale_es_ES"
+            "displayNameKey": "locale_es_ES",
+            "displayName": "Spanish (Spain)"
           },
           {
             "value": "it-IT",
-            "displayNameKey": "locale_it_IT"
+            "displayNameKey": "locale_it_IT",
+            "displayName": "Italian (Italy)"
           },
           {
             "value": "ja-JP",
-            "displayNameKey": "locale_ja_JP"
+            "displayNameKey": "locale_ja_JP",
+            "displayName": "Japanese (Japan)"
           },
           {
             "value": "zh-CN",
-            "displayNameKey": "locale_zh_CN"
+            "displayNameKey": "locale_zh_CN",
+            "displayName": "Chinese (China)"
           }
         ],
         "value": {
           "value": "en-US",
-          "displayNameKey": "locale_en_US"
+          "displayNameKey": "locale_en_US",
+          "displayName": "English (United States)"
         }
       }
     },
@@ -282,26 +361,31 @@
           "items": [
             {
               "value": "compact",
-              "displayNameKey": "pill_style_compact"
+              "displayNameKey": "pill_style_compact",
+              "displayName": "Compact"
             },
             {
               "value": "expanded",
-              "displayNameKey": "pill_style_expanded"
+              "displayNameKey": "pill_style_expanded",
+              "displayName": "Expanded"
             }
           ],
           "value": {
             "value": "expanded",
-            "displayNameKey": "pill_style_expanded"
+            "displayNameKey": "pill_style_expanded",
+            "displayName": "Expanded"
           }
         },
         {
           "name": "showPresetLabels",
           "displayNameKey": "format_pill_showPresetLabels",
+          "displayName": "Show preset labels",
           "value": true
         },
         {
           "name": "pillBackgroundColor",
           "displayNameKey": "format_pill_background",
+          "displayName": "Pill background",
           "value": {
             "value": "#123456"
           }
@@ -309,6 +393,7 @@
         {
           "name": "pillBorderColor",
           "displayNameKey": "format_pill_border",
+          "displayName": "Pill border",
           "value": {
             "value": "#abcdef"
           }
@@ -316,6 +401,7 @@
         {
           "name": "pillTextColor",
           "displayNameKey": "format_pill_text",
+          "displayName": "Pill text",
           "value": {
             "value": "#654321"
           }
@@ -323,6 +409,7 @@
         {
           "name": "pillFontSize",
           "displayNameKey": "format_pill_fontSize",
+          "displayName": "Pill font size",
           "value": 14,
           "options": {
             "minValue": {
@@ -338,6 +425,7 @@
         {
           "name": "pillMinWidth",
           "displayNameKey": "format_pill_minWidth",
+          "displayName": "Pill minimum width",
           "value": 300,
           "options": {
             "minValue": {
@@ -353,32 +441,38 @@
       ],
       "name": "pill",
       "displayNameKey": "format_pill_displayName",
+      "displayName": "Pill",
       "pillStyle": {
         "name": "pillStyle",
         "displayNameKey": "format_pill_pillStyle",
         "items": [
           {
             "value": "compact",
-            "displayNameKey": "pill_style_compact"
+            "displayNameKey": "pill_style_compact",
+            "displayName": "Compact"
           },
           {
             "value": "expanded",
-            "displayNameKey": "pill_style_expanded"
+            "displayNameKey": "pill_style_expanded",
+            "displayName": "Expanded"
           }
         ],
         "value": {
           "value": "expanded",
-          "displayNameKey": "pill_style_expanded"
+          "displayNameKey": "pill_style_expanded",
+          "displayName": "Expanded"
         }
       },
       "showPresetLabels": {
         "name": "showPresetLabels",
         "displayNameKey": "format_pill_showPresetLabels",
+        "displayName": "Show preset labels",
         "value": true
       },
       "pillBackgroundColor": {
         "name": "pillBackgroundColor",
         "displayNameKey": "format_pill_background",
+        "displayName": "Pill background",
         "value": {
           "value": "#123456"
         }
@@ -386,6 +480,7 @@
       "pillBorderColor": {
         "name": "pillBorderColor",
         "displayNameKey": "format_pill_border",
+        "displayName": "Pill border",
         "value": {
           "value": "#abcdef"
         }
@@ -393,6 +488,7 @@
       "pillTextColor": {
         "name": "pillTextColor",
         "displayNameKey": "format_pill_text",
+        "displayName": "Pill text",
         "value": {
           "value": "#654321"
         }
@@ -400,6 +496,7 @@
       "pillFontSize": {
         "name": "pillFontSize",
         "displayNameKey": "format_pill_fontSize",
+        "displayName": "Pill font size",
         "value": 14,
         "options": {
           "minValue": {
@@ -415,6 +512,7 @@
       "pillMinWidth": {
         "name": "pillMinWidth",
         "displayNameKey": "format_pill_minWidth",
+        "displayName": "Pill minimum width",
         "value": 300,
         "options": {
           "minValue": {
@@ -433,24 +531,29 @@
         {
           "name": "showQuickApply",
           "displayNameKey": "format_buttons_showQuickApply",
+          "displayName": "Show Today quick apply",
           "value": true
         },
         {
           "name": "showClear",
           "displayNameKey": "format_buttons_showClear",
+          "displayName": "Show Clear",
           "value": false
         }
       ],
       "name": "buttons",
       "displayNameKey": "format_buttons_displayName",
+      "displayName": "Buttons",
       "showQuickApply": {
         "name": "showQuickApply",
         "displayNameKey": "format_buttons_showQuickApply",
+        "displayName": "Show Today quick apply",
         "value": true
       },
       "showClear": {
         "name": "showClear",
         "displayNameKey": "format_buttons_showClear",
+        "displayName": "Show Clear",
         "value": false
       }
     }

--- a/artifacts/resource-audit.json
+++ b/artifacts/resource-audit.json
@@ -271,7 +271,23 @@
     ],
     "missing": []
   },
+  "preset_lastWeek": {
+    "present": [
+      "en-AU",
+      "en-US",
+      "fr-FR"
+    ],
+    "missing": []
+  },
   "preset_lastYear": {
+    "present": [
+      "en-AU",
+      "en-US",
+      "fr-FR"
+    ],
+    "missing": []
+  },
+  "preset_mtd": {
     "present": [
       "en-AU",
       "en-US",

--- a/capabilities.json
+++ b/capabilities.json
@@ -139,7 +139,14 @@
         "pillBackgroundColor": {
           "displayNameKey": "format_pill_background",
           "displayName": "Pill background",
-          "type": { "fill": { "solid": { "color": true } } }
+          "type": { "fill": { "solid": { "color": true } } },
+          "default": {
+            "solid": {
+              "color": {
+                "expr": { "Literal": { "Value": "\"#ffffff\"" } }
+              }
+            }
+          }
         },
         "pillBorderColor": {
           "displayNameKey": "format_pill_border",
@@ -149,7 +156,14 @@
         "pillTextColor": {
           "displayNameKey": "format_pill_text",
           "displayName": "Pill text",
-          "type": { "fill": { "solid": { "color": true } } }
+          "type": { "fill": { "solid": { "color": true } } },
+          "default": {
+            "solid": {
+              "color": {
+                "expr": { "Literal": { "Value": "\"#000000\"" } }
+              }
+            }
+          }
         },
         "pillFontSize": {
           "displayNameKey": "format_pill_fontSize",

--- a/src/components/DateRangeFilter.tsx
+++ b/src/components/DateRangeFilter.tsx
@@ -475,8 +475,17 @@ export const DateRangeFilter: React.FC<DateRangeFilterProps> = ({
     if (!manualEdit) {
       return;
     }
-    manualInputRef.current?.focus();
-    manualInputRef.current?.select();
+    const input = manualInputRef.current;
+    if (!input) {
+      return;
+    }
+    input.focus();
+    const length = input.value.length;
+    try {
+      input.setSelectionRange(length, length);
+    } catch {
+      // Some browsers may throw if the input type does not support selection ranges.
+    }
   }, [manualEdit]);
 
   useEffect(() => {

--- a/src/styles/date-range-filter.css
+++ b/src/styles/date-range-filter.css
@@ -133,6 +133,8 @@
   color: inherit;
   padding: 0;
   cursor: pointer;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .date-range-filter__chevron:focus-visible {

--- a/src/visual/formattingSettings.ts
+++ b/src/visual/formattingSettings.ts
@@ -6,58 +6,66 @@ const { SimpleCard, ItemDropdown, NumUpDown, ColorPicker, ToggleSwitch, Model } 
   formattingSettings;
 
 export const PRESET_ITEMS = [
-  { value: "today", displayNameKey: "preset_today" },
-  { value: "yesterday", displayNameKey: "preset_yesterday" },
-  { value: "last7", displayNameKey: "preset_last7" },
-  { value: "last30", displayNameKey: "preset_last30" },
-  { value: "lastWeek", displayNameKey: "preset_lastWeek" },
-  { value: "thisMonth", displayNameKey: "preset_thisMonth" },
-  { value: "lastMonth", displayNameKey: "preset_lastMonth" },
-  { value: "mtd", displayNameKey: "preset_mtd" },
-  { value: "qtd", displayNameKey: "preset_qtd" },
-  { value: "ytd", displayNameKey: "preset_ytd" },
-  { value: "lastYear", displayNameKey: "preset_lastYear" },
-  { value: "custom", displayNameKey: "preset_custom" },
+  { value: "today", displayNameKey: "preset_today", displayName: "Today" },
+  { value: "yesterday", displayNameKey: "preset_yesterday", displayName: "Yesterday" },
+  { value: "last7", displayNameKey: "preset_last7", displayName: "Last 7 days" },
+  { value: "last30", displayNameKey: "preset_last30", displayName: "Last 30 days" },
+  { value: "lastWeek", displayNameKey: "preset_lastWeek", displayName: "Last week" },
+  { value: "thisMonth", displayNameKey: "preset_thisMonth", displayName: "This month" },
+  { value: "lastMonth", displayNameKey: "preset_lastMonth", displayName: "Last month" },
+  { value: "mtd", displayNameKey: "preset_mtd", displayName: "Month to date" },
+  { value: "qtd", displayNameKey: "preset_qtd", displayName: "Quarter to date" },
+  { value: "ytd", displayNameKey: "preset_ytd", displayName: "Year to date" },
+  { value: "lastYear", displayNameKey: "preset_lastYear", displayName: "Last year" },
+  { value: "custom", displayNameKey: "preset_custom", displayName: "Custom" },
 ];
 
 export const PILL_STYLE_ITEMS = [
-  { value: "compact", displayNameKey: "pill_style_compact" },
-  { value: "expanded", displayNameKey: "pill_style_expanded" },
+  { value: "compact", displayNameKey: "pill_style_compact", displayName: "Compact" },
+  { value: "expanded", displayNameKey: "pill_style_expanded", displayName: "Expanded" },
 ];
 
-export type WeekStartDropdownItem = ILocalizedItemMember & { value: string };
+export interface WeekStartDropdownItem extends ILocalizedItemMember {
+  value: string;
+  displayName?: string;
+}
 
 export const WEEK_START_ITEMS: WeekStartDropdownItem[] = [
-  { value: "0", displayNameKey: "weekday_sun" },
-  { value: "1", displayNameKey: "weekday_mon" },
-  { value: "2", displayNameKey: "weekday_tue" },
-  { value: "3", displayNameKey: "weekday_wed" },
-  { value: "4", displayNameKey: "weekday_thu" },
-  { value: "5", displayNameKey: "weekday_fri" },
-  { value: "6", displayNameKey: "weekday_sat" },
+  { value: "0", displayNameKey: "weekday_sun", displayName: "Sunday" },
+  { value: "1", displayNameKey: "weekday_mon", displayName: "Monday" },
+  { value: "2", displayNameKey: "weekday_tue", displayName: "Tuesday" },
+  { value: "3", displayNameKey: "weekday_wed", displayName: "Wednesday" },
+  { value: "4", displayNameKey: "weekday_thu", displayName: "Thursday" },
+  { value: "5", displayNameKey: "weekday_fri", displayName: "Friday" },
+  { value: "6", displayNameKey: "weekday_sat", displayName: "Saturday" },
 ];
 
-export type LocaleDropdownItem = ILocalizedItemMember & { value: string };
+export interface LocaleDropdownItem extends ILocalizedItemMember {
+  value: string;
+  displayName?: string;
+}
 
 export const LOCALE_ITEMS: LocaleDropdownItem[] = [
-  { value: "en-AU", displayNameKey: "locale_en_AU" },
-  { value: "en-US", displayNameKey: "locale_en_US" },
-  { value: "en-GB", displayNameKey: "locale_en_GB" },
-  { value: "fr-FR", displayNameKey: "locale_fr_FR" },
-  { value: "de-DE", displayNameKey: "locale_de_DE" },
-  { value: "es-ES", displayNameKey: "locale_es_ES" },
-  { value: "it-IT", displayNameKey: "locale_it_IT" },
-  { value: "ja-JP", displayNameKey: "locale_ja_JP" },
-  { value: "zh-CN", displayNameKey: "locale_zh_CN" },
+  { value: "en-AU", displayNameKey: "locale_en_AU", displayName: "English (Australia)" },
+  { value: "en-US", displayNameKey: "locale_en_US", displayName: "English (United States)" },
+  { value: "en-GB", displayNameKey: "locale_en_GB", displayName: "English (United Kingdom)" },
+  { value: "fr-FR", displayNameKey: "locale_fr_FR", displayName: "French (France)" },
+  { value: "de-DE", displayNameKey: "locale_de_DE", displayName: "German (Germany)" },
+  { value: "es-ES", displayNameKey: "locale_es_ES", displayName: "Spanish (Spain)" },
+  { value: "it-IT", displayNameKey: "locale_it_IT", displayName: "Italian (Italy)" },
+  { value: "ja-JP", displayNameKey: "locale_ja_JP", displayName: "Japanese (Japan)" },
+  { value: "zh-CN", displayNameKey: "locale_zh_CN", displayName: "Chinese (China)" },
 ];
 
 export class DefaultsCardSettings extends SimpleCard {
   public name = "defaults";
   public displayNameKey = "format_defaults_displayName";
+  public displayName = "Defaults";
 
   public defaultPreset = new ItemDropdown({
     name: "defaultPreset",
     displayNameKey: "format_defaults_defaultPreset",
+    displayName: "Default preset",
     items: PRESET_ITEMS,
     value: PRESET_ITEMS[2],
   });
@@ -65,6 +73,7 @@ export class DefaultsCardSettings extends SimpleCard {
   public weekStartsOn = new ItemDropdown({
     name: "weekStartsOn",
     displayNameKey: "format_defaults_weekStartsOn",
+    displayName: "Week starts on",
     items: WEEK_START_ITEMS,
     value: WEEK_START_ITEMS[1],
   });
@@ -72,6 +81,7 @@ export class DefaultsCardSettings extends SimpleCard {
   public locale = new ItemDropdown({
     name: "locale",
     displayNameKey: "format_defaults_locale",
+    displayName: "Locale",
     items: LOCALE_ITEMS,
     value: LOCALE_ITEMS[0],
   });
@@ -82,10 +92,12 @@ export class DefaultsCardSettings extends SimpleCard {
 export class PillCardSettings extends SimpleCard {
   public name = "pill";
   public displayNameKey = "format_pill_displayName";
+  public displayName = "Pill";
 
   public pillStyle = new ItemDropdown({
     name: "pillStyle",
     displayNameKey: "format_pill_pillStyle",
+    displayName: "Pill style",
     items: PILL_STYLE_ITEMS,
     value: PILL_STYLE_ITEMS[0],
   });
@@ -93,30 +105,35 @@ export class PillCardSettings extends SimpleCard {
   public showPresetLabels = new ToggleSwitch({
     name: "showPresetLabels",
     displayNameKey: "format_pill_showPresetLabels",
+    displayName: "Show preset labels",
     value: true,
   });
 
   public pillBackgroundColor = new ColorPicker({
     name: "pillBackgroundColor",
     displayNameKey: "format_pill_background",
-    value: { value: "" },
+    displayName: "Pill background",
+    value: { value: "#ffffff" },
   });
 
   public pillBorderColor = new ColorPicker({
     name: "pillBorderColor",
     displayNameKey: "format_pill_border",
+    displayName: "Pill border",
     value: { value: "" },
   });
 
   public pillTextColor = new ColorPicker({
     name: "pillTextColor",
     displayNameKey: "format_pill_text",
-    value: { value: "" },
+    displayName: "Pill text",
+    value: { value: "#000000" },
   });
 
   public pillFontSize = new NumUpDown({
     name: "pillFontSize",
     displayNameKey: "format_pill_fontSize",
+    displayName: "Pill font size",
     value: 12,
     options: {
       minValue: { value: 6, type: powerbi.visuals.ValidatorType.Min },
@@ -127,6 +144,7 @@ export class PillCardSettings extends SimpleCard {
   public pillMinWidth = new NumUpDown({
     name: "pillMinWidth",
     displayNameKey: "format_pill_minWidth",
+    displayName: "Pill minimum width",
     value: 260,
     options: {
       minValue: { value: 120, type: powerbi.visuals.ValidatorType.Min },
@@ -148,16 +166,19 @@ export class PillCardSettings extends SimpleCard {
 export class ButtonsCardSettings extends SimpleCard {
   public name = "buttons";
   public displayNameKey = "format_buttons_displayName";
+  public displayName = "Buttons";
 
   public showQuickApply = new ToggleSwitch({
     name: "showQuickApply",
     displayNameKey: "format_buttons_showQuickApply",
+    displayName: "Show Today quick apply",
     value: false,
   });
 
   public showClear = new ToggleSwitch({
     name: "showClear",
     displayNameKey: "format_buttons_showClear",
+    displayName: "Show Clear",
     value: true,
   });
 

--- a/src/visual/visual.tsx
+++ b/src/visual/visual.tsx
@@ -517,7 +517,7 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
     buttons: {},
   };
 
-  private formattingSettingsService = new FormattingSettingsService();
+  private formattingSettingsService: FormattingSettingsService;
 
   private formattingSettings: PresetDateSlicerFormattingSettingsModel =
     new PresetDateSlicerFormattingSettingsModel();
@@ -554,6 +554,7 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
     this.events = this.host.eventService;
     this.allowInteractions = this.host.hostCapabilities?.allowInteractions ?? true;
     this.strings = getVisualStrings(this.localizationManager);
+    this.formattingSettingsService = new FormattingSettingsService(this.localizationManager);
 
     this.rootElement = document.createElement("div");
     this.rootElement.className = "preset-date-slicer";


### PR DESCRIPTION
## Summary
- set default pill colors in capabilities and formatting settings and provide fallback display names for the format pane
- align the pill chevron to the edge and improve manual date editing focus behaviour
- initialise the formatting settings service with the localization manager so display names resolve correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ef14dee0448321a7b3dce8279ff359