### PR TITLE
Fix preset mapping, filter application, and package config

### DIFF
--- a/pbiviz.json
+++ b/pbiviz.json
@@ -17,7 +17,7 @@
   "assets": {
     "icon": "assets/icon.svg"
   },
-  "capabilities": "capabilities.json",
+  "capabilities": "./capabilities.json",
   "dependencies": null,
   "stringResources": [
     "stringResources/en-US/resources.resjson",

--- a/test/visual-integration.spec.ts
+++ b/test/visual-integration.spec.ts
@@ -338,13 +338,27 @@ describe("PresetDateSlicerVisual integration", () => {
 
     (visual as unknown as { applyRangeFilter(r: typeof range): void }).applyRangeFilter(range);
 
-    expect(host.applyJsonFilter).toHaveBeenCalledTimes(1);
-    const appliedFilter = host.applyJsonFilter.mock.calls[0][0] as models.IAdvancedFilter;
+    expect(host.applyJsonFilter).toHaveBeenCalledTimes(2);
+    expect(host.applyJsonFilter).toHaveBeenNthCalledWith(
+      1,
+      undefined,
+      "general",
+      "filter",
+      powerbi.FilterAction.remove,
+    );
+    const appliedFilterArg = host.applyJsonFilter.mock.calls[1][0] as models.AdvancedFilter;
+    const appliedFilter =
+      typeof appliedFilterArg?.toJSON === "function"
+        ? appliedFilterArg.toJSON()
+        : (appliedFilterArg as unknown as models.IAdvancedFilter);
     expect(appliedFilter.target).toEqual({ table: "Sales", column: "OrderDate" });
     expect(appliedFilter.conditions).toEqual([
       { operator: "GreaterThanOrEqual", value: toISODate(range.from) },
       { operator: "LessThanOrEqual", value: toISODate(range.to) },
     ]);
+    expect(host.applyJsonFilter.mock.calls[1][1]).toBe("general");
+    expect(host.applyJsonFilter.mock.calls[1][2]).toBe("filter");
+    expect(host.applyJsonFilter.mock.calls[1][3]).toBe(powerbi.FilterAction.merge);
 
     expect(host.selectionManager.selectCallCount).toBe(1);
     const keys = host.selectionManager.selectCalls[0].map((id) => (id as MockSelectionId).key);


### PR DESCRIPTION
## Summary
- align formatting defaults and persisted state so legacy `defaultPreset` values hydrate `presetId`
- apply range filters through the host API with an advanced filter and avoid redundant persistence to stop repeated updates
- point the pbiviz packaging metadata at `capabilities.json` and update integration tests for the new behavior

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68f040d7312c83219addbb5af851eaac