### PR TITLE
Fix local date serialization and ensure filters apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ settings clamp the interactive calendar and preset ranges, preventing selections
 The `PresetDateSlicerVisual` mirrors any existing report filters on the bound date column and merges new ranges via
 `applyJsonFilter`, ensuring the host model always stays synchronised.
 
+All date serialisation utilities normalise to the local calendar day (`YYYY-MM-DD`) rather than UTC timestamps, preventing
+the off-by-one behaviour that surfaces when browsers and Power BI disagree on timezone offsets.
+
 ## Running the demo
 
 The Vite workspace still offers a quick way to observe the outside-iframe handshake.

--- a/src/date/utils.ts
+++ b/src/date/utils.ts
@@ -135,7 +135,10 @@ export function endOfCalendar(date: Date, weekStartsOn: number = 1): Date {
 }
 
 export function toISODate(date: Date): string {
-  return date.toISOString().slice(0, 10);
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, "0");
+  const d = `${date.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 export function fromISODate(value: string): Date | null {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -55,7 +55,10 @@ export function parseTargetFromQueryName(
 }
 
 export function toDateOnlyIso(date: Date): string {
-  return date.toISOString().slice(0, 10);
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, "0");
+  const d = `${date.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 export function extentFromValues(values: unknown[]): { min?: Date; max?: Date } {

--- a/src/visual/visual.tsx
+++ b/src/visual/visual.tsx
@@ -857,13 +857,7 @@ export class PresetDateSlicerVisual implements powerbi.extensibility.visual.IVis
       { operator: "LessThanOrEqual", value: toDateOnlyIso(constrained.to) },
     ]);
 
-    this.host.applyJsonFilter(
-      undefined as unknown as models.IFilter,
-      "general",
-      "filter",
-      powerbi.FilterAction.remove,
-    );
-    this.host.applyJsonFilter(filter, "general", "filter", powerbi.FilterAction.merge);
+    this.host.applyJsonFilter(filter.toJSON(), "general", "filter", powerbi.FilterAction.merge);
   }
 
   private persistState(range: DateRange, presetId: string): void {

--- a/test/date-serialization.spec.ts
+++ b/test/date-serialization.spec.ts
@@ -1,0 +1,37 @@
+describe("local date serialization", () => {
+  it("uses local calendar fields instead of UTC", () => {
+    const fakeDate = {
+      getFullYear: () => 2024,
+      getMonth: () => 0,
+      getDate: () => 1,
+      toISOString: () => "2023-12-31T14:00:00.000Z",
+    } as unknown as Date;
+
+    jest.isolateModules(() => {
+      const { toISODate } = require("../src/date/utils");
+      const { toDateOnlyIso } = require("../src/utils/filters");
+
+      expect(toISODate(fakeDate)).toBe("2024-01-01");
+      expect(toDateOnlyIso(fakeDate)).toBe("2024-01-01");
+    });
+  });
+
+  it("does not rely on Date#toISOString for serialization", () => {
+    const date = new Date(2024, 0, 1);
+    const spy = jest.spyOn(date, "toISOString").mockImplementation(() => {
+      throw new Error("Unexpected toISOString call");
+    });
+
+    jest.isolateModules(() => {
+      const { toISODate } = require("../src/date/utils");
+      const { toDateOnlyIso } = require("../src/utils/filters");
+
+      expect(() => toISODate(date)).not.toThrow();
+      expect(() => toDateOnlyIso(date)).not.toThrow();
+      expect(toISODate(date)).toBe("2024-01-01");
+      expect(toDateOnlyIso(date)).toBe("2024-01-01");
+    });
+
+    spy.mockRestore();
+  });
+});

--- a/test/visual-integration.spec.ts
+++ b/test/visual-integration.spec.ts
@@ -338,27 +338,16 @@ describe("PresetDateSlicerVisual integration", () => {
 
     (visual as unknown as { applyRangeFilter(r: typeof range): void }).applyRangeFilter(range);
 
-    expect(host.applyJsonFilter).toHaveBeenCalledTimes(2);
-    expect(host.applyJsonFilter).toHaveBeenNthCalledWith(
-      1,
-      undefined,
-      "general",
-      "filter",
-      powerbi.FilterAction.remove,
-    );
-    const appliedFilterArg = host.applyJsonFilter.mock.calls[1][0] as models.AdvancedFilter;
-    const appliedFilter =
-      typeof appliedFilterArg?.toJSON === "function"
-        ? appliedFilterArg.toJSON()
-        : (appliedFilterArg as unknown as models.IAdvancedFilter);
+    expect(host.applyJsonFilter).toHaveBeenCalledTimes(1);
+    const appliedFilter = host.applyJsonFilter.mock.calls[0][0] as models.IAdvancedFilter;
     expect(appliedFilter.target).toEqual({ table: "Sales", column: "OrderDate" });
     expect(appliedFilter.conditions).toEqual([
       { operator: "GreaterThanOrEqual", value: toISODate(range.from) },
       { operator: "LessThanOrEqual", value: toISODate(range.to) },
     ]);
-    expect(host.applyJsonFilter.mock.calls[1][1]).toBe("general");
-    expect(host.applyJsonFilter.mock.calls[1][2]).toBe("filter");
-    expect(host.applyJsonFilter.mock.calls[1][3]).toBe(powerbi.FilterAction.merge);
+    expect(host.applyJsonFilter.mock.calls[0][1]).toBe("general");
+    expect(host.applyJsonFilter.mock.calls[0][2]).toBe("filter");
+    expect(host.applyJsonFilter.mock.calls[0][3]).toBe(powerbi.FilterAction.merge);
 
     expect(host.selectionManager.selectCallCount).toBe(1);
     const keys = host.selectionManager.selectCalls[0].map((id) => (id as MockSelectionId).key);


### PR DESCRIPTION
## Summary
- normalise toISODate and toDateOnlyIso to emit local YYYY-MM-DD strings
- apply Power BI filters by sending the advanced filter JSON instead of a model wrapper
- cover the new behaviour with unit tests and document the local date-only serialisation approach

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68f0493bd1208321948283bcc82e78f7