### PR TITLE
Replace MUI calendar with PrimeReact inline calendar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,12 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@emotion/react": "^11.13.3",
-        "@emotion/styled": "^11.13.0",
-        "@mui/material": "^5.15.18",
-        "@mui/x-date-pickers": "^6.20.2",
-        "@mui/x-date-pickers-pro": "^6.20.2",
         "d3-selection": "3.0.0",
-        "dayjs": "^1.11.13",
         "powerbi-models": "2.0.1",
         "powerbi-visuals-utils-formattingmodel": "6.2.2",
         "powerbi-visuals-utils-tooltiputils": "6.0.4",
+        "primeicons": "^6.0.1",
+        "primereact": "^10.6.4",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -45,6 +41,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -102,6 +99,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.28.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.3",
@@ -139,6 +137,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -146,6 +145,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -181,6 +181,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -188,6 +189,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -215,6 +217,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.28.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.4"
@@ -442,6 +445,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.27.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -454,6 +458,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.28.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -470,6 +475,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.28.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -491,167 +497,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@emotion/babel-plugin": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/serialize": "^1.3.3",
-        "babel-plugin-macros": "^3.1.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "hoist-non-react-statics": "^3.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/styled": {
-      "version": "11.14.1",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
-      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/is-prop-valid": "^1.3.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-        "@emotion/utils": "^1.4.2"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0-rc.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -735,44 +580,6 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -1302,6 +1109,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1319,6 +1127,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1335,10 +1144,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1457,844 +1268,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.4.tgz",
-      "integrity": "sha512-BIktMapG3r4iXwIhYNpvk97ZfYWTreBBQTWjQKbNbzI64+ULHfYavQEX2w99aSWHS58DvXESWIgbD9adKcUOBw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/@mui/material": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
-      "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/core-downloads-tracker": "^7.3.4",
-        "@mui/system": "^7.3.3",
-        "@mui/types": "^7.4.7",
-        "@mui/utils": "^7.3.3",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.1.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.3",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "license": "MIT"
-    },
-    "node_modules/@mui/private-theming": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.3.tgz",
-      "integrity": "sha512-OJM+9nj5JIyPUvsZ5ZjaeC9PfktmK+W5YaVLToLR8L0lB/DGmv1gcKE43ssNLSvpoW71Hct0necfade6+kW3zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styled-engine": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.3.tgz",
-      "integrity": "sha512-CmFxvRJIBCEaWdilhXMw/5wFJ1+FT9f3xt+m2pPXhHPeVIbBg9MnMvNSJjdALvnQJMPw8jLhrUtXmN7QAZV2fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.3.tgz",
-      "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/private-theming": "^7.3.3",
-        "@mui/styled-engine": "^7.3.3",
-        "@mui/types": "^7.4.7",
-        "@mui/utils": "^7.3.3",
-        "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/types": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.7.tgz",
-      "integrity": "sha512-8vVje9rdEr1rY8oIkYgP+Su5Kwl6ik7O3jQ0wl78JGSmiZhRHV+vkjooGdKD8pbtZbutXFVTWQYshu2b3sG9zw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.3.tgz",
-      "integrity": "sha512-kwNAUh7bLZ7mRz9JZ+6qfRnnxbE4Zuc+RzXnhSpRSxjTlSTj7b4JxRLXpG+MVtPVtqks5k/XC8No1Vs3x4Z2gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/types": "^7.4.7",
-        "@types/prop-types": "^15.7.15",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.1.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "license": "MIT"
-    },
-    "node_modules/@mui/x-date-pickers": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.14.0.tgz",
-      "integrity": "sha512-fz8z1hoi1tbG1QUcZAkQdiO3GsCOpUeRfyANXDDzDN88L4VqwNEyrv0wmzmCfIX2sgur4gWwWJzMuCvauMgXRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.3",
-        "@mui/x-internals": "8.14.0",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
-        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
-        "dayjs": "^1.10.7",
-        "luxon": "^3.0.2",
-        "moment": "^2.29.4",
-        "moment-hijri": "^2.1.2 || ^3.0.0",
-        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        },
-        "date-fns-jalali": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        },
-        "moment-hijri": {
-          "optional": true
-        },
-        "moment-jalaali": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/x-date-pickers-pro": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers-pro/-/x-date-pickers-pro-8.14.0.tgz",
-      "integrity": "sha512-OnXWrF/8hXjwXxlc0bZhEmIYYZlGzLYeoM23GCw9LT4lUkId7CincmwtqwRjdnCmni6UDhmwsU/Om5wKCuojMA==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.3",
-        "@mui/x-date-pickers": "8.14.0",
-        "@mui/x-internals": "8.14.0",
-        "@mui/x-license": "8.14.0",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
-        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
-        "dayjs": "^1.10.7",
-        "luxon": "^3.0.2",
-        "moment": "^2.29.4",
-        "moment-hijri": "^2.1.2 || ^3.0.0",
-        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        },
-        "date-fns-jalali": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        },
-        "moment-hijri": {
-          "optional": true
-        },
-        "moment-jalaali": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/x-internals": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.14.0.tgz",
-      "integrity": "sha512-esYyl61nuuFXiN631TWuPh2tqdoyTdBI/4UXgwH3rytF8jiWvy6prPBPRHEH1nvW3fgw9FoBI48FlOO+yEI8xg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.3",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@mui/x-license": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-license/-/x-license-8.14.0.tgz",
-      "integrity": "sha512-JHbse66fduorxM3zL483PBxGkDDcOKRxT+k8hCVmC+5J0Je1Y/2WqfOeFIIh5OukoWB4ar0Cepv/9vQ03slOyQ==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.3",
-        "@mui/x-internals": "8.14.0",
-        "@mui/x-telemetry": "8.14.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@jsonjoy.com/util": {
-      "version": "1.9.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "^1.0.0",
-        "@jsonjoy.com/codegen": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-dev.20240529-082515-213b5e33ab",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-dev.20240529-082515-213b5e33ab.tgz",
-      "integrity": "sha512-3ic6fc6BHstgM+MGqJEVx3zt9g5THxVXm3VVFUfdeplPqAWWgW2QoKfZDLT10s+pi+MAkpgEBP0kgRidf81Rsw==",
-      "deprecated": "This package has been replaced by @base-ui-components/react",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.6",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@mui/types": "^7.2.14-dev.20240529-082515-213b5e33ab",
-        "@mui/utils": "^6.0.0-dev.20240529-082515-213b5e33ab",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/base/node_modules/@mui/utils": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
-      "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/types": "~7.2.24",
-        "@types/prop-types": "^15.7.14",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/base/node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "license": "MIT"
-    },
-    "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
-      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/@mui/material": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
-      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.18.0",
-        "@mui/system": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "license": "MIT"
-    },
-    "node_modules/@mui/private-theming": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
-      "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.17.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styled-engine": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
-      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.13.5",
-        "@emotion/serialize": "^1.3.3",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
-      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.17.1",
-        "@mui/styled-engine": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/types": {
-      "version": "7.2.24",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
-      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
-      "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/types": "~7.2.15",
-        "@types/prop-types": "^15.7.12",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "license": "MIT"
-    },
-    "node_modules/@mui/x-date-pickers": {
-      "version": "6.20.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.20.2.tgz",
-      "integrity": "sha512-x1jLg8R+WhvkmUETRfX2wC+xJreMii78EXKLl6r3G+ggcAZlPyt0myID1Amf6hvJb9CtR7CgUo8BwR+1Vx9Ggw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/base": "^5.0.0-beta.22",
-        "@mui/utils": "^5.14.16",
-        "@types/react-transition-group": "^4.4.8",
-        "clsx": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.8.6",
-        "@mui/system": "^5.8.0",
-        "date-fns": "^2.25.0 || ^3.2.0",
-        "date-fns-jalali": "^2.13.0-0",
-        "dayjs": "^1.10.7",
-        "luxon": "^3.0.2",
-        "moment": "^2.29.4",
-        "moment-hijri": "^2.1.2",
-        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        },
-        "date-fns-jalali": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        },
-        "moment-hijri": {
-          "optional": true
-        },
-        "moment-jalaali": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/x-date-pickers-pro": {
-      "version": "6.20.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers-pro/-/x-date-pickers-pro-6.20.2.tgz",
-      "integrity": "sha512-yCH7Kl9XEkPA+VQc+6Y9Vn58uLGyjYIrUpGFxWBqdhde1C+14sMEwDfeBAF7FIlKylu32kU57SJi+QSZHQ4ZgA==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/base": "^5.0.0-beta.22",
-        "@mui/utils": "^5.14.16",
-        "@mui/x-date-pickers": "6.20.2",
-        "@mui/x-license-pro": "6.10.2",
-        "clsx": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.8.6",
-        "@mui/system": "^5.8.0",
-        "date-fns": "^2.25.0 || ^3.2.0",
-        "date-fns-jalali": "^2.13.0-0",
-        "dayjs": "^1.10.7",
-        "luxon": "^3.0.2",
-        "moment": "^2.29.4",
-        "moment-hijri": "^2.1.2",
-        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        },
-        "date-fns-jalali": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        },
-        "moment-hijri": {
-          "optional": true
-        },
-        "moment-jalaali": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/x-license-pro": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-license-pro/-/x-license-pro-6.10.2.tgz",
-      "integrity": "sha512-Baw3shilU+eHgU+QYKNPFUKvfS5rSyNJ98pQx02E0gKA22hWp/XAt88K1qUfUMPlkPpvg/uci6gviQSSLZkuKw==",
-      "deprecated": "In MUI X v7 the name of this package changed to @mui/x-license to reflect the existence of the premium plan.",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/utils": "^5.13.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -2342,16 +1315,6 @@
       "version": "1.0.0-next.29",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2600,7 +1563,10 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -3271,6 +2237,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3286,6 +2253,7 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.17.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3300,6 +2268,7 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv-keywords": {
@@ -3451,15 +2420,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/atomically": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
-      "integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
-      "dependencies": {
-        "stubborn-fs": "^1.2.5",
-        "when-exit": "^2.1.1"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "dev": true,
@@ -3550,7 +2510,10 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -4016,6 +2979,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4158,15 +3122,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "dev": true,
@@ -4276,50 +3231,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/conf": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-11.0.2.tgz",
-      "integrity": "sha512-jjyhlQ0ew/iwmtwsS2RaB6s8DBifcE2GYBEaw2SJDUY/slJJbNfY4GlDVzOs/ff8cM/Wua5CikqXgbFl5eu85A==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.12.0",
-        "ajv-formats": "^2.1.1",
-        "atomically": "^2.0.0",
-        "debounce-fn": "^5.1.2",
-        "dot-prop": "^7.2.0",
-        "env-paths": "^3.0.0",
-        "json-schema-typed": "^8.0.1",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conf/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/conf/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "dev": true,
@@ -4394,7 +3305,10 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
       "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -4410,7 +3324,10 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -4612,46 +3529,14 @@
         "node": ">=12"
       }
     },
-    "node_modules/dayjs": {
-      "version": "1.11.18",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
-      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
-      "license": "MIT"
-    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/debounce-fn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
-      "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/debounce-fn/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5028,18 +3913,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/errno": {
       "version": "0.1.8",
       "dev": true,
@@ -5054,6 +3927,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -5122,6 +3996,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5641,6 +4516,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5681,6 +4557,7 @@
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5791,12 +4668,6 @@
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "license": "MIT"
     },
     "node_modules/find-up": {
@@ -5992,6 +4863,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6289,6 +5161,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6306,21 +5179,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -6566,6 +5424,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -6659,6 +5518,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-binary-path": {
@@ -6685,6 +5545,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7637,6 +6498,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -7659,18 +6521,13 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
-      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify": {
       "version": "1.3.0",
@@ -7917,6 +6774,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/loader-runner": {
@@ -8237,6 +7095,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -8313,12 +7172,6 @@
     "node_modules/node-int64": {
       "version": "0.4.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-machine-id": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
-      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -8572,6 +7425,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -8597,6 +7451,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -8716,6 +7571,7 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -8751,6 +7607,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8787,6 +7644,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -9330,6 +8188,35 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/primeicons": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-6.0.1.tgz",
+      "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA==",
+      "license": "MIT"
+    },
+    "node_modules/primereact": {
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.6.4.tgz",
+      "integrity": "sha512-P6bJkh54p6o0UOvNjkva0n1uYRPL8YrMxkT4YEZxxNIX1B/1eWOYGpBKwvLO839+G6aWJ8re9BIeouHWgp2R2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-transition-group": "^4.4.1",
+        "react-transition-group": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "dev": true,
@@ -9627,6 +8514,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9637,14 +8525,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT"
-    },
     "node_modules/resolve": {
       "version": "1.22.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -9684,6 +8567,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10554,12 +9438,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -10573,6 +9451,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10958,6 +9837,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tty-browserify": {
@@ -11121,15 +10001,6 @@
       "version": "1.4.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -11546,12 +10417,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/when-exit": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.4.tgz",
-      "integrity": "sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==",
-      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -13,25 +13,21 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@emotion/react": "^11.13.3",
-    "@emotion/styled": "^11.13.0",
-    "@mui/material": "^5.15.18",
-    "@mui/x-date-pickers-pro": "^6.20.2",
-    "@mui/x-date-pickers": "^6.20.2",
     "d3-selection": "3.0.0",
-    "dayjs": "^1.11.13",
     "powerbi-models": "2.0.1",
     "powerbi-visuals-utils-formattingmodel": "6.2.2",
     "powerbi-visuals-utils-tooltiputils": "6.0.4",
+    "primeicons": "^6.0.1",
+    "primereact": "^10.6.4",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/d3-selection": "3.0.7",
     "@types/jest": "29.5.11",
     "@types/node": "22.8.4",
     "@types/react": "18.2.34",
     "@types/react-dom": "18.2.14",
-    "@types/d3-selection": "3.0.7",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "eslint": "8.57.1",

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,23 +1,16 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { ThemeProvider, ThemeOptions, createTheme } from "@mui/material/styles";
-import Box from "@mui/material/Box";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { DateRangeCalendar } from "@mui/x-date-pickers-pro/DateRangeCalendar";
-import { PickerSelectionState } from "@mui/x-date-pickers/internals";
-import dayjs, { Dayjs } from "dayjs";
-import updateLocale from "dayjs/plugin/updateLocale";
-import "dayjs/locale/en";
+import { Calendar as PrimeCalendar, CalendarPassThroughOptions } from "primereact/calendar";
+import { addLocale } from "primereact/api";
+import { FormEvent } from "primereact/ts-helpers";
 
 import { ensureWithinRange, normalizeRange } from "../date";
 import { DateRange } from "../types/dateRange";
 import { formatTemplate } from "../utils/localization";
 
+import "../styles/primereact.css";
 import "../styles/calendar.css";
 
-dayjs.extend(updateLocale);
-
-type CalendarProps = {
+type Props = {
   range: DateRange;
   onRangeChange: (range: DateRange) => void;
   locale: string;
@@ -31,9 +24,29 @@ type CalendarProps = {
   };
 };
 
+type RangeChangeEvent = FormEvent<(Date | null)[]>;
+
+type DayLabelFormatter = Intl.DateTimeFormat;
+
+type ViewDateChangeEvent = {
+  value: Date;
+};
+
 const FALLBACK_LOCALE = "en";
 
-const loadedLocales = new Set<string>([FALLBACK_LOCALE]);
+type IntlLocaleWeekInfo = {
+  weekInfo?: { firstDay?: string | string[] };
+};
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+  sun: 0,
+};
 
 function normalizeLocale(locale?: string): string {
   if (!locale) {
@@ -42,55 +55,88 @@ function normalizeLocale(locale?: string): string {
   return locale.toLowerCase().replace("_", "-");
 }
 
-async function loadLocale(locale: string): Promise<string> {
-  const normalized = normalizeLocale(locale);
-  const candidates = [normalized, normalized.split("-")[0]].filter(Boolean) as string[];
-
-  for (const candidate of candidates) {
-    if (loadedLocales.has(candidate)) {
-      dayjs.locale(candidate);
-      return candidate;
-    }
-
-    try {
-      await import(
-        /* webpackChunkName: "dayjs-locale-[request]" */ `dayjs/locale/${candidate}.js`
-      );
-      loadedLocales.add(candidate);
-      dayjs.locale(candidate);
-      return candidate;
-    } catch (error) {
-      // Continue trying fallback candidates
-    }
+function getLocaleWeekStart(locale: string): number | undefined {
+  const localeCtor = (Intl as unknown as { Locale?: new (tag: string) => IntlLocaleWeekInfo }).Locale;
+  if (!localeCtor) {
+    return undefined;
   }
-
-  dayjs.locale(FALLBACK_LOCALE);
-  return FALLBACK_LOCALE;
+  try {
+    const info = new localeCtor(locale);
+    const firstDay = info.weekInfo?.firstDay;
+    if (Array.isArray(firstDay)) {
+      const candidate = firstDay[0];
+      if (typeof candidate === "string") {
+        const key = candidate.toLowerCase();
+        return key in WEEKDAY_INDEX ? WEEKDAY_INDEX[key as keyof typeof WEEKDAY_INDEX] : undefined;
+      }
+    }
+    if (typeof firstDay === "string") {
+      const key = firstDay.toLowerCase();
+      return key in WEEKDAY_INDEX ? WEEKDAY_INDEX[key as keyof typeof WEEKDAY_INDEX] : undefined;
+    }
+  } catch (error) {
+    return undefined;
+  }
+  return undefined;
 }
 
-function toDayjs(date: Date | undefined, locale: string): Dayjs | null {
-  if (!date) {
-    return null;
+function buildLocaleOptions(locale: string, weekStartsOn?: number, defaultWeekStart?: number) {
+  const formatterLocale = locale || FALLBACK_LOCALE;
+  const baseSunday = new Date(Date.UTC(2021, 0, 3));
+  const dayNames: string[] = [];
+  const dayNamesShort: string[] = [];
+  const dayNamesMin: string[] = [];
+
+  const longDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "long" });
+  const shortDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "short" });
+  const narrowDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "narrow" });
+
+  for (let index = 0; index < 7; index += 1) {
+    const date = new Date(baseSunday);
+    date.setDate(baseSunday.getDate() + index);
+    dayNames.push(longDayFormatter.format(date));
+    dayNamesShort.push(shortDayFormatter.format(date));
+    dayNamesMin.push(narrowDayFormatter.format(date));
   }
-  return dayjs(date).locale(locale);
+
+  const monthNames: string[] = [];
+  const monthNamesShort: string[] = [];
+
+  const longMonthFormatter = new Intl.DateTimeFormat(formatterLocale, { month: "long" });
+  const shortMonthFormatter = new Intl.DateTimeFormat(formatterLocale, { month: "short" });
+
+  for (let month = 0; month < 12; month += 1) {
+    const date = new Date(Date.UTC(2021, month, 1));
+    monthNames.push(longMonthFormatter.format(date));
+    monthNamesShort.push(shortMonthFormatter.format(date));
+  }
+
+  return {
+    dayNames,
+    dayNamesShort,
+    dayNamesMin,
+    monthNames,
+    monthNamesShort,
+    firstDayOfWeek: weekStartsOn ?? defaultWeekStart ?? 0,
+  };
 }
 
-type DayjsRangeValue = [Dayjs | null, Dayjs | null];
+function toCalendarValue(range: DateRange): (Date | null)[] {
+  return [range.from ? new Date(range.from) : null, range.to ? new Date(range.to) : null];
+}
 
-function formatVisibleMonth(value: DayjsRangeValue | null, locale: string): string | undefined {
+function coerceDate(value: string | number | Date | null | undefined): Date | undefined {
   if (!value) {
     return undefined;
   }
-
-  const start = value[0];
-  if (!start) {
-    return undefined;
+  if (value instanceof Date) {
+    return value;
   }
-
-  return start.locale(locale).format("MMMM YYYY");
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 }
 
-export const Calendar: React.FC<CalendarProps> = ({
+export const Calendar: React.FC<Props> = ({
   range,
   onRangeChange,
   locale,
@@ -99,200 +145,133 @@ export const Calendar: React.FC<CalendarProps> = ({
   weekStartsOn,
   strings,
 }) => {
-  const [activeLocale, setActiveLocale] = useState<string>(FALLBACK_LOCALE);
-  const [pickerValue, setPickerValue] = useState<DayjsRangeValue>([
-    toDayjs(range.from, FALLBACK_LOCALE),
-    toDayjs(range.to, FALLBACK_LOCALE),
-  ]);
-  const [visibleMonthLabel, setVisibleMonthLabel] = useState<string | undefined>(
-    formatVisibleMonth(pickerValue, FALLBACK_LOCALE),
+  const normalizedLocale = normalizeLocale(locale);
+
+  const activeLocale = useMemo(() => {
+    try {
+      new Intl.DateTimeFormat(normalizedLocale).format(new Date());
+      return normalizedLocale;
+    } catch (error) {
+      return FALLBACK_LOCALE;
+    }
+  }, [normalizedLocale]);
+
+  const localeWeekStart = useMemo(() => getLocaleWeekStart(activeLocale), [activeLocale]);
+
+  const localeOptions = useMemo(
+    () => buildLocaleOptions(activeLocale, weekStartsOn, localeWeekStart),
+    [activeLocale, localeWeekStart, weekStartsOn],
   );
 
   useEffect(() => {
-    let isMounted = true;
-    loadLocale(locale)
-      .then((resolved) => {
-        if (!isMounted) {
-          return;
-        }
-        if (weekStartsOn != null) {
-          dayjs.updateLocale(resolved, { weekStart: weekStartsOn });
-        }
-        setActiveLocale(resolved);
-      })
-      .catch(() => {
-        if (!isMounted) {
-          return;
-        }
-        if (weekStartsOn != null) {
-          dayjs.updateLocale(FALLBACK_LOCALE, { weekStart: weekStartsOn });
-        }
-        setActiveLocale(FALLBACK_LOCALE);
-      });
+    addLocale(normalizedLocale, localeOptions);
+  }, [localeOptions, normalizedLocale]);
 
-    return () => {
-      isMounted = false;
-    };
-  }, [locale, weekStartsOn]);
+  const monthLabelFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(activeLocale, {
+        month: "long",
+        year: "numeric",
+      }),
+    [activeLocale],
+  );
+
+  const dayLabelFormatter: DayLabelFormatter = useMemo(
+    () => new Intl.DateTimeFormat(activeLocale, { dateStyle: "full" }),
+    [activeLocale],
+  );
+
+  const [viewDate, setViewDate] = useState<Date>(() => new Date(range.from));
 
   useEffect(() => {
-    const nextValue: DayjsRangeValue = [
-      toDayjs(range.from, activeLocale),
-      toDayjs(range.to, activeLocale),
-    ];
-    setPickerValue(nextValue);
-    setVisibleMonthLabel(formatVisibleMonth(nextValue, activeLocale));
-  }, [range.from, range.to, activeLocale]);
+    setViewDate(new Date(range.from));
+  }, [range.from]);
 
-  const theme = useMemo(
-    () =>
-      createTheme({
-        palette: {
-          primary: {
-            main: "var(--visual-accent, #2563eb)",
-            contrastText: "var(--visual-accent-text, #ffffff)",
-          },
-          text: {
-            primary: "var(--visual-text, #0f172a)",
-            secondary: "var(--visual-text-muted, #64748b)",
-          },
-          background: {
-            paper: "var(--visual-surface, #ffffff)",
-          },
-          divider: "var(--visual-border, rgba(15, 23, 42, 0.12))",
+  const ariaLabel = useMemo(() => {
+    const monthLabel = monthLabelFormatter.format(viewDate);
+    return formatTemplate(strings.ariaLabelTemplate, monthLabel);
+  }, [monthLabelFormatter, strings.ariaLabelTemplate, viewDate]);
+
+  const passThrough = useMemo<CalendarPassThroughOptions>(
+    () => ({
+      previousButton: {
+        root: {
+          "aria-label": strings.previousMonth,
+          title: strings.previousMonth,
         },
-        typography: {
-          fontFamily: "inherit",
-          fontSize: 14,
+      },
+      nextButton: {
+        root: {
+          "aria-label": strings.nextMonth,
+          title: strings.nextMonth,
         },
-        components: {
-          MuiPickersCalendarHeader: {
-            styleOverrides: {
-              label: {
-                color: "var(--visual-text, #0f172a)",
-                fontWeight: 600,
-              },
-              switchViewButton: {
-                color: "var(--visual-text, #0f172a)",
-              },
-            },
-          },
-          MuiPickersDay: {
-            styleOverrides: {
-              root: {
-                fontSize: "1rem",
-              },
-              today: {
-                borderColor: "var(--visual-accent, #2563eb)",
-              },
-              dayWithMargin: {
-                margin: 0,
-              },
-            },
-          },
-          MuiDateRangePickerDay: {
-            styleOverrides: {
-              rangeIntervalDayHighlight: {
-                backgroundColor: "var(--visual-accent, #2563eb)",
-                color: "var(--visual-accent-text, #ffffff)",
-              },
-              rangeIntervalDayHighlightStart: {
-                borderRadius: "var(--ds-radius-small, 6px) 0 0 var(--ds-radius-small, 6px)",
-              },
-              rangeIntervalDayHighlightEnd: {
-                borderRadius: "0 var(--ds-radius-small, 6px) var(--ds-radius-small, 6px) 0",
-              },
-              rangeIntervalPreview: {
-                borderColor: "var(--visual-accent, rgba(37, 99, 235, 0.3))",
-              },
-              rangeIntervalDayPreview: {
-                borderColor: "var(--visual-accent, rgba(37, 99, 235, 0.3))",
-              },
-            },
-          },
-        },
-      } as ThemeOptions),
-    [],
+      },
+      dayLabel: (options) => {
+        const rawContext = options?.context?.date;
+        const rawDate = Array.isArray(rawContext) ? rawContext[0] : rawContext;
+        const parsed = coerceDate(rawDate as Date | string | number | null | undefined);
+        if (!parsed) {
+          return {};
+        }
+        return {
+          "aria-label": dayLabelFormatter.format(parsed),
+        };
+      },
+    }),
+    [dayLabelFormatter, strings.nextMonth, strings.previousMonth],
   );
 
   const handleChange = useCallback(
-    (value: DayjsRangeValue, _selectionState?: PickerSelectionState) => {
-      setPickerValue(value);
+    (event: RangeChangeEvent) => {
+      const value = event.value ?? [];
+      const start = value[0] ?? value[1] ?? null;
+      const end = value[1] ?? value[0] ?? null;
 
-      const [start, end] = value;
       if (!start && !end) {
         return;
       }
 
       if (start && !end) {
-        const normalized = ensureWithinRange(
-          normalizeRange(start.toDate(), start.toDate()),
-          dataMin,
-          dataMax,
-        );
+        const normalized = ensureWithinRange(normalizeRange(start, start), dataMin, dataMax);
         onRangeChange(normalized);
         return;
       }
 
       if (start && end) {
-        const normalized = ensureWithinRange(
-          normalizeRange(start.toDate(), end.toDate()),
-          dataMin,
-          dataMax,
-        );
+        const normalized = ensureWithinRange(normalizeRange(start, end), dataMin, dataMax);
         onRangeChange(normalized);
       }
     },
     [dataMax, dataMin, onRangeChange],
   );
 
-  const minDate = useMemo(() => (dataMin ? dayjs(dataMin) : undefined), [dataMin]);
-  const maxDate = useMemo(() => (dataMax ? dayjs(dataMax) : undefined), [dataMax]);
+  const handleViewDateChange = useCallback((event: ViewDateChangeEvent) => {
+    setViewDate(new Date(event.value));
+  }, []);
 
-  const ariaLabel = useMemo(() => {
-    if (!visibleMonthLabel) {
-      return undefined;
-    }
-    return formatTemplate(strings.ariaLabelTemplate, visibleMonthLabel);
-  }, [strings.ariaLabelTemplate, visibleMonthLabel]);
+  const calendarValue = useMemo(() => toCalendarValue(range), [range]);
 
-  const handleMonthChange = useCallback(
-    (month: Dayjs) => {
-      setVisibleMonthLabel(month.locale(activeLocale).format("MMMM YYYY"));
-    },
-    [activeLocale],
-  );
+  const minDate = useMemo(() => (dataMin ? new Date(dataMin) : undefined), [dataMin]);
+  const maxDate = useMemo(() => (dataMax ? new Date(dataMax) : undefined), [dataMax]);
 
   return (
-    <ThemeProvider theme={theme}>
-      <LocalizationProvider
-        dateAdapter={AdapterDayjs}
-        adapterLocale={activeLocale}
-        localeText={{
-          previousMonth: strings.previousMonth,
-          nextMonth: strings.nextMonth,
-        }}
-      >
-        <Box className="calendar" aria-label={ariaLabel}>
-          <DateRangeCalendar
-            value={pickerValue}
-            onChange={handleChange}
-            onMonthChange={handleMonthChange}
-            minDate={minDate}
-            maxDate={maxDate}
-            calendars={2}
-            slotProps={{
-              previousIconButton: {
-                "aria-label": strings.previousMonth,
-              },
-              nextIconButton: {
-                "aria-label": strings.nextMonth,
-              },
-            }}
-          />
-        </Box>
-      </LocalizationProvider>
-    </ThemeProvider>
+    <div className="calendar" aria-label={ariaLabel}>
+      <PrimeCalendar
+        value={calendarValue}
+        onChange={handleChange}
+        onViewDateChange={handleViewDateChange}
+        selectionMode="range"
+        numberOfMonths={2}
+        inline
+        locale={normalizedLocale}
+        minDate={minDate}
+        maxDate={maxDate}
+        pt={passThrough}
+        panelClassName="calendar__panel"
+        showOtherMonths
+        selectOtherMonths
+      />
+    </div>
   );
 };
 

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -6,50 +6,122 @@
   gap: var(--ds-spacing-2);
 }
 
-.calendar .MuiDateRangeCalendar-root {
+.calendar__panel {
   width: 100%;
-  background: transparent;
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+  padding: var(--ds-spacing-2) var(--ds-spacing-3);
 }
 
-.calendar .MuiDateRangeCalendar-root .MuiPickersDay-root {
-  border-radius: var(--ds-radius-small);
+.calendar__panel .p-datepicker-group-container {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ds-spacing-3);
 }
 
-.calendar .MuiDateRangeCalendar-root .MuiDateRangePickerDay-rangeIntervalDayHighlightStart,
-.calendar .MuiDateRangeCalendar-root .MuiDateRangePickerDay-rangeIntervalDayHighlightEnd {
-  border-radius: var(--ds-radius-small);
+.calendar__panel .p-datepicker-group {
+  flex: 1 1 0;
 }
 
-.calendar .MuiDateRangeCalendar-root .MuiDateRangePickerDay-dayOutsideRangeInterval {
-  color: var(--visual-text-muted, var(--ds-color-text-muted));
-}
-
-.calendar .MuiDateRangeCalendar-root .Mui-disabled {
-  color: rgba(148, 163, 184, 0.6);
-}
-
-.calendar .MuiDateRangeCalendar-root .MuiPickersArrowSwitcher-root button:hover,
-.calendar .MuiDateRangeCalendar-root .MuiPickersArrowSwitcher-root button:focus-visible {
-  background-color: var(--visual-surface, var(--ds-color-surface));
-  outline: none;
-}
-
-.calendar .MuiDateRangeCalendar-root .MuiPickersCalendarHeader-labelContainer {
+.calendar__panel .p-datepicker-header {
   color: var(--visual-text, var(--ds-color-text));
+  padding: 0;
+  margin-bottom: var(--ds-spacing-2);
+}
+
+.calendar__panel .p-datepicker-prev,
+.calendar__panel .p-datepicker-next {
+  color: var(--visual-text, var(--ds-color-text));
+  border-radius: var(--ds-radius-small);
+}
+
+.calendar__panel .p-datepicker-prev:focus-visible,
+.calendar__panel .p-datepicker-next:focus-visible {
+  outline: 2px solid var(--visual-accent, #2563eb);
+  outline-offset: 2px;
+}
+
+.calendar__panel .p-datepicker-title {
   font-weight: 600;
 }
 
-.calendar .MuiDateRangeCalendar-root .MuiPickersCalendarHeader-label {
-  font-size: var(--ds-font-size-medium);
+.calendar__panel .p-datepicker table {
+  width: 100%;
+  border-collapse: collapse;
 }
 
-.calendar .MuiDateRangeCalendar-root .MuiDayCalendar-weekDayLabel {
+.calendar__panel .p-datepicker table thead th {
   color: var(--visual-text-muted, var(--ds-color-text-muted));
   font-size: var(--ds-font-size-small);
   text-transform: uppercase;
+  font-weight: 500;
+  padding-bottom: var(--ds-spacing-1);
 }
 
-.calendar .MuiDateRangeCalendar-root .MuiPickersDay-today::after {
+.calendar__panel .p-datepicker table td {
+  padding: 0;
+}
+
+.calendar__panel .p-datepicker table td > span {
+  border-radius: var(--ds-radius-small);
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.calendar__panel .p-datepicker table td.p-datepicker-other-month > span {
+  color: var(--visual-text-muted, var(--ds-color-text-muted));
+  opacity: 0.6;
+}
+
+.calendar__panel .p-highlight {
+  background: var(--visual-accent, #2563eb) !important;
+  color: var(--visual-accent-text, #ffffff) !important;
+}
+
+.calendar__panel .p-highlight.p-disabled {
+  opacity: 0.5;
+}
+
+.calendar__panel .p-datepicker table td > span.p-disabled {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.calendar__panel .p-datepicker table td > span:focus-visible {
+  outline: 2px solid var(--visual-accent, #2563eb);
+  outline-offset: 2px;
+}
+
+.calendar__panel .p-datepicker-today > span::after {
   display: none;
+}
+
+.calendar__panel .p-datepicker-range-highlight {
+  background: var(--visual-accent-weak, rgba(37, 99, 235, 0.12));
+}
+
+.calendar__panel .p-datepicker-range-start > span,
+.calendar__panel .p-datepicker-range-end > span {
+  background: var(--visual-accent, #2563eb);
+  color: var(--visual-accent-text, #ffffff);
+}
+
+.calendar__panel .p-datepicker-range-start > span {
+  border-radius: var(--ds-radius-small) 0 0 var(--ds-radius-small);
+}
+
+.calendar__panel .p-datepicker-range-end > span {
+  border-radius: 0 var(--ds-radius-small) var(--ds-radius-small) 0;
+}
+
+.calendar__panel .p-datepicker-group:not(:last-child) .p-datepicker-calendar {
+  border-right: 1px solid var(--visual-border, rgba(15, 23, 42, 0.12));
+  margin-right: var(--ds-spacing-3);
+  padding-right: var(--ds-spacing-3);
+}
+
+.calendar__panel .p-datepicker-group:last-child .p-datepicker-calendar {
+  margin-left: var(--ds-spacing-3);
+  padding-left: var(--ds-spacing-3);
 }
 

--- a/src/styles/primereact.css
+++ b/src/styles/primereact.css
@@ -1,0 +1,9 @@
+@import "primereact/resources/themes/lara-light-blue/theme.css";
+@import "primereact/resources/primereact.min.css";
+@import "primeicons/primeicons.css";
+
+.calendar .p-component {
+  font-family: var(--ds-font-family, inherit);
+  font-size: var(--ds-font-size-medium, 14px);
+}
+


### PR DESCRIPTION
## Summary
- replace the MUI Dayjs-based calendar with an inline PrimeReact range calendar that keeps rendering inside the dialog and respects locale/week start settings
- add PrimeReact theme assets and tailored styling so the picker matches the visual’s layout and uses existing design tokens
- update dependencies to drop the unused MUI/dayjs stack in favor of primereact/primeicons

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68f0709f94c483218f38cd54a96cd780