### PR TITLE
Fix calendar locale registration and dialog focus handling

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -1,0 +1,16 @@
+# Date selector maintenance notes
+
+## Locale registration
+
+* `src/utils/calendarLocale.ts` centralizes locale normalization and PrimeReact locale registration. `normalizeLocaleTag` canonicalizes host/format pane input (underscores, casing, invalid tags) and always falls back to `en` if `Intl` cannot load the locale.
+* `buildCalendarLocaleOptions` creates the `dayNames`, `monthNames`, and guaranteed `firstDayOfWeek`. The calendar component calls `registerCalendarLocale` during render so the PrimeReact calendar always sees a `firstDayOfWeek` value before it mounts.
+
+## Dialog focus and background handling
+
+* `src/components/Popover.tsx` now moves focus using `useLayoutEffect` and restores it on cleanup. This avoids Chrome's "Blocked aria-hidden" warning when `aria-modal="true"` is applied.
+* `src/components/DateRangeFilter.tsx` sets `inert` on the visual root while the popover is open and restores the previous value when it closes. If the browser does not support `inert`, the plain attribute is toggled as a no-op.
+
+## Calendar containment
+
+* The PrimeReact calendar continues to render inline inside the popover (no portal). The locale registration changes ensure the inline calendar never throws on missing locale data, so it behaves the same inside the Power BI dialog.
+

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,7 +5,8 @@ module.exports = {
   moduleFileExtensions: ["ts", "tsx", "js"],
   moduleNameMapper: {
     "^.+\\.(css)$": "<rootDir>/test/mocks/styleMock.js",
-    "^.+\\.(png|jpg|jpeg|gif|svg)$": "<rootDir>/test/mocks/fileMock.js"
+    "^.+\\.(png|jpg|jpeg|gif|svg)$": "<rootDir>/test/mocks/fileMock.js",
+    "^primereact/(.*)$": "<rootDir>/test/mocks/primereact/$1"
   },
   setupFilesAfterEnv: [],
 };

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,11 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Calendar as PrimeCalendar, CalendarPassThroughOptions } from "primereact/calendar";
-import { addLocale } from "primereact/api";
 import { FormEvent } from "primereact/ts-helpers";
 
 import { ensureWithinRange, normalizeRange } from "../date";
 import { DateRange } from "../types/dateRange";
 import { formatTemplate } from "../utils/localization";
+import {
+  FALLBACK_LOCALE,
+  buildCalendarLocaleOptions,
+  getLocaleWeekStart,
+  normalizeLocaleTag,
+  registerCalendarLocale,
+} from "../utils/calendarLocale";
 
 import "../styles/primereact.css";
 import "../styles/calendar.css";
@@ -32,95 +38,6 @@ type ViewDateChangeEvent = {
   value: Date;
 };
 
-const FALLBACK_LOCALE = "en";
-
-type IntlLocaleWeekInfo = {
-  weekInfo?: { firstDay?: string | string[] };
-};
-
-const WEEKDAY_INDEX: Record<string, number> = {
-  mon: 1,
-  tue: 2,
-  wed: 3,
-  thu: 4,
-  fri: 5,
-  sat: 6,
-  sun: 0,
-};
-
-function normalizeLocale(locale?: string): string {
-  if (!locale) {
-    return FALLBACK_LOCALE;
-  }
-  return locale.toLowerCase().replace("_", "-");
-}
-
-function getLocaleWeekStart(locale: string): number | undefined {
-  const localeCtor = (Intl as unknown as { Locale?: new (tag: string) => IntlLocaleWeekInfo }).Locale;
-  if (!localeCtor) {
-    return undefined;
-  }
-  try {
-    const info = new localeCtor(locale);
-    const firstDay = info.weekInfo?.firstDay;
-    if (Array.isArray(firstDay)) {
-      const candidate = firstDay[0];
-      if (typeof candidate === "string") {
-        const key = candidate.toLowerCase();
-        return key in WEEKDAY_INDEX ? WEEKDAY_INDEX[key as keyof typeof WEEKDAY_INDEX] : undefined;
-      }
-    }
-    if (typeof firstDay === "string") {
-      const key = firstDay.toLowerCase();
-      return key in WEEKDAY_INDEX ? WEEKDAY_INDEX[key as keyof typeof WEEKDAY_INDEX] : undefined;
-    }
-  } catch (error) {
-    return undefined;
-  }
-  return undefined;
-}
-
-function buildLocaleOptions(locale: string, weekStartsOn?: number, defaultWeekStart?: number) {
-  const formatterLocale = locale || FALLBACK_LOCALE;
-  const baseSunday = new Date(Date.UTC(2021, 0, 3));
-  const dayNames: string[] = [];
-  const dayNamesShort: string[] = [];
-  const dayNamesMin: string[] = [];
-
-  const longDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "long" });
-  const shortDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "short" });
-  const narrowDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "narrow" });
-
-  for (let index = 0; index < 7; index += 1) {
-    const date = new Date(baseSunday);
-    date.setDate(baseSunday.getDate() + index);
-    dayNames.push(longDayFormatter.format(date));
-    dayNamesShort.push(shortDayFormatter.format(date));
-    dayNamesMin.push(narrowDayFormatter.format(date));
-  }
-
-  const monthNames: string[] = [];
-  const monthNamesShort: string[] = [];
-
-  const longMonthFormatter = new Intl.DateTimeFormat(formatterLocale, { month: "long" });
-  const shortMonthFormatter = new Intl.DateTimeFormat(formatterLocale, { month: "short" });
-
-  for (let month = 0; month < 12; month += 1) {
-    const date = new Date(Date.UTC(2021, month, 1));
-    monthNames.push(longMonthFormatter.format(date));
-    monthNamesShort.push(shortMonthFormatter.format(date));
-  }
-
-  return {
-    dayNames,
-    dayNamesShort,
-    dayNamesMin,
-    monthNames,
-    monthNamesShort,
-    firstDayOfWeek: weekStartsOn ?? defaultWeekStart ?? 0,
-  };
-}
-
 function toCalendarValue(range: DateRange): (Date | null)[] {
   return [range.from ? new Date(range.from) : null, range.to ? new Date(range.to) : null];
 }
@@ -145,40 +62,33 @@ export const Calendar: React.FC<Props> = ({
   weekStartsOn,
   strings,
 }) => {
-  const normalizedLocale = normalizeLocale(locale);
-
-  const activeLocale = useMemo(() => {
-    try {
-      new Intl.DateTimeFormat(normalizedLocale).format(new Date());
-      return normalizedLocale;
-    } catch (error) {
-      return FALLBACK_LOCALE;
-    }
-  }, [normalizedLocale]);
-
-  const localeWeekStart = useMemo(() => getLocaleWeekStart(activeLocale), [activeLocale]);
-
+  const normalizedLocale = useMemo(() => normalizeLocaleTag(locale), [locale]);
+  const localeWeekStart = useMemo(() => getLocaleWeekStart(normalizedLocale), [normalizedLocale]);
   const localeOptions = useMemo(
-    () => buildLocaleOptions(activeLocale, weekStartsOn, localeWeekStart),
-    [activeLocale, localeWeekStart, weekStartsOn],
+    () => buildCalendarLocaleOptions(normalizedLocale, weekStartsOn, localeWeekStart),
+    [localeWeekStart, normalizedLocale, weekStartsOn],
   );
-
-  useEffect(() => {
-    addLocale(normalizedLocale, localeOptions);
-  }, [localeOptions, normalizedLocale]);
+  const fallbackOptions = useMemo(
+    () => buildCalendarLocaleOptions(FALLBACK_LOCALE, weekStartsOn, localeWeekStart),
+    [localeWeekStart, weekStartsOn],
+  );
+  const calendarLocale = useMemo(
+    () => registerCalendarLocale(normalizedLocale, localeOptions, fallbackOptions),
+    [fallbackOptions, localeOptions, normalizedLocale],
+  );
 
   const monthLabelFormatter = useMemo(
     () =>
-      new Intl.DateTimeFormat(activeLocale, {
+      new Intl.DateTimeFormat(normalizedLocale, {
         month: "long",
         year: "numeric",
       }),
-    [activeLocale],
+    [normalizedLocale],
   );
 
   const dayLabelFormatter: DayLabelFormatter = useMemo(
-    () => new Intl.DateTimeFormat(activeLocale, { dateStyle: "full" }),
-    [activeLocale],
+    () => new Intl.DateTimeFormat(normalizedLocale, { dateStyle: "full" }),
+    [normalizedLocale],
   );
 
   const [viewDate, setViewDate] = useState<Date>(() => new Date(range.from));
@@ -206,7 +116,7 @@ export const Calendar: React.FC<Props> = ({
           title: strings.nextMonth,
         },
       },
-      dayLabel: (options) => {
+      dayLabel: (options: { context?: { date?: Date | Date[] } }) => {
         const rawContext = options?.context?.date;
         const rawDate = Array.isArray(rawContext) ? rawContext[0] : rawContext;
         const parsed = coerceDate(rawDate as Date | string | number | null | undefined);
@@ -263,7 +173,7 @@ export const Calendar: React.FC<Props> = ({
         selectionMode="range"
         numberOfMonths={2}
         inline
-        locale={normalizedLocale}
+        locale={calendarLocale}
         minDate={minDate}
         maxDate={maxDate}
         pt={passThrough}

--- a/src/components/DateRangeFilter.tsx
+++ b/src/components/DateRangeFilter.tsx
@@ -273,6 +273,43 @@ export const DateRangeFilter: React.FC<DateRangeFilterProps> = ({
     return ((rounded % 7) + 7) % 7;
   }, [weekStartsOn]);
 
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const inertable = container as HTMLElement & { inert?: boolean };
+    const hadInertAttribute = container.hasAttribute("inert");
+    const previousInert = typeof inertable.inert === "boolean" ? inertable.inert : undefined;
+    const previousAriaHidden = container.getAttribute("aria-hidden");
+    if ("inert" in inertable) {
+      inertable.inert = true;
+    } else {
+      container.setAttribute("inert", "");
+    }
+    if (previousAriaHidden !== null) {
+      container.removeAttribute("aria-hidden");
+    }
+    return () => {
+      if ("inert" in inertable) {
+        if (typeof previousInert === "boolean") {
+          inertable.inert = previousInert;
+        } else {
+          inertable.inert = false;
+        }
+      } else if (!hadInertAttribute) {
+        container.removeAttribute("inert");
+      } else {
+        container.setAttribute("inert", "");
+      }
+      if (previousAriaHidden !== null) {
+        container.setAttribute("aria-hidden", previousAriaHidden);
+      }
+    };
+  }, [open]);
 
   const commitChange = useCallback(
     (range: DateRange, presetId: string, options?: { force?: boolean }) => {

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useId } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useId } from "react";
 import { DatePreset } from "../date";
 import { DateRange } from "../types/dateRange";
 import { VisualStrings } from "../types/localization";
@@ -51,11 +51,16 @@ export const Popover: React.FC<PopoverProps> = ({
   const previousActive = useRef<HTMLElement | null>(null);
   const headingId = useId();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     previousActive.current = document.activeElement as HTMLElement | null;
     const focusable = getFocusable(containerRef.current);
     focusable[0]?.focus();
+    return () => {
+      previousActive.current?.focus();
+    };
+  }, []);
 
+  useEffect(() => {
     const handlePointerDown = (event: MouseEvent | TouchEvent) => {
       const target = event.target as Node;
       if (!containerRef.current?.contains(target)) {
@@ -70,7 +75,6 @@ export const Popover: React.FC<PopoverProps> = ({
     return () => {
       doc.removeEventListener("mousedown", handlePointerDown);
       doc.removeEventListener("touchstart", handlePointerDown);
-      previousActive.current?.focus();
     };
   }, [onClose]);
 

--- a/src/types/primereact.d.ts
+++ b/src/types/primereact.d.ts
@@ -1,0 +1,34 @@
+declare module "primereact/calendar" {
+  import * as React from "react";
+
+  export interface CalendarPassThroughOptions {
+    [key: string]: unknown;
+    dayLabel?: (options: any) => Record<string, unknown>;
+  }
+
+  export interface CalendarProps {
+    value?: unknown;
+    onChange?: (event: any) => void;
+    onViewDateChange?: (event: any) => void;
+    selectionMode?: string;
+    numberOfMonths?: number;
+    inline?: boolean;
+    locale?: string;
+    minDate?: Date;
+    maxDate?: Date;
+    pt?: CalendarPassThroughOptions;
+    panelClassName?: string;
+    showOtherMonths?: boolean;
+    selectOtherMonths?: boolean;
+  }
+
+  export class Calendar extends React.Component<CalendarProps> {}
+}
+
+declare module "primereact/api" {
+  export function addLocale(locale: string, options: Record<string, unknown>): void;
+}
+
+declare module "primereact/ts-helpers" {
+  export type FormEvent<T> = { value?: T };
+}

--- a/src/utils/calendarLocale.ts
+++ b/src/utils/calendarLocale.ts
@@ -1,0 +1,164 @@
+import { addLocale } from "primereact/api";
+
+export const FALLBACK_LOCALE = "en";
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+  sun: 0,
+};
+
+type IntlLocaleWeekInfo = {
+  weekInfo?: { firstDay?: string | string[] };
+};
+
+function canonicalizeLocale(locale: string): string | undefined {
+  try {
+    const canonical = Intl.getCanonicalLocales(locale)[0];
+    return canonical ?? undefined;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+function resolveLocale(locale: string): string | undefined {
+  try {
+    const formatter = new Intl.DateTimeFormat(locale);
+    return formatter.resolvedOptions().locale;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+function matchesResolvedLocale(candidate: string): string | undefined {
+  const resolved = resolveLocale(candidate);
+  if (!resolved) {
+    return undefined;
+  }
+  const canonicalCandidate = canonicalizeLocale(candidate) ?? candidate;
+  return resolved.toLowerCase() === canonicalCandidate.toLowerCase() ? canonicalCandidate : undefined;
+}
+
+export function normalizeLocaleTag(locale?: string): string {
+  if (!locale) {
+    return FALLBACK_LOCALE;
+  }
+  const sanitized = locale.trim().replace(/_/g, "-");
+  if (!sanitized) {
+    return FALLBACK_LOCALE;
+  }
+  const candidates = [sanitized];
+  const canonical = canonicalizeLocale(sanitized);
+  if (canonical) {
+    candidates.unshift(canonical);
+  }
+  for (const candidate of candidates) {
+    const match = matchesResolvedLocale(candidate);
+    if (match) {
+      return match;
+    }
+  }
+  return FALLBACK_LOCALE;
+}
+
+export function getLocaleWeekStart(locale: string): number | undefined {
+  const LocaleCtor = (Intl as unknown as { Locale?: new (tag: string) => IntlLocaleWeekInfo }).Locale;
+  if (!LocaleCtor) {
+    return undefined;
+  }
+  try {
+    const info = new LocaleCtor(locale);
+    const firstDay = info.weekInfo?.firstDay;
+    const normalize = (value: string) => {
+      const key = value.toLowerCase();
+      return key in WEEKDAY_INDEX ? WEEKDAY_INDEX[key as keyof typeof WEEKDAY_INDEX] : undefined;
+    };
+    if (Array.isArray(firstDay)) {
+      for (const candidate of firstDay) {
+        if (typeof candidate === "string") {
+          const resolved = normalize(candidate);
+          if (typeof resolved === "number") {
+            return resolved;
+          }
+        }
+      }
+    } else if (typeof firstDay === "string") {
+      return normalize(firstDay);
+    }
+  } catch (error) {
+    return undefined;
+  }
+  return undefined;
+}
+
+export function buildCalendarLocaleOptions(
+  locale: string,
+  weekStartsOn?: number,
+  defaultWeekStart?: number,
+) {
+  const formatterLocale = locale || FALLBACK_LOCALE;
+  const baseSunday = new Date(Date.UTC(2021, 0, 3));
+  const dayNames: string[] = [];
+  const dayNamesShort: string[] = [];
+  const dayNamesMin: string[] = [];
+
+  const longDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "long" });
+  const shortDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "short" });
+  const narrowDayFormatter = new Intl.DateTimeFormat(formatterLocale, { weekday: "narrow" });
+
+  for (let index = 0; index < 7; index += 1) {
+    const date = new Date(baseSunday);
+    date.setDate(baseSunday.getDate() + index);
+    dayNames.push(longDayFormatter.format(date));
+    dayNamesShort.push(shortDayFormatter.format(date));
+    dayNamesMin.push(narrowDayFormatter.format(date));
+  }
+
+  const monthNames: string[] = [];
+  const monthNamesShort: string[] = [];
+
+  const longMonthFormatter = new Intl.DateTimeFormat(formatterLocale, { month: "long" });
+  const shortMonthFormatter = new Intl.DateTimeFormat(formatterLocale, { month: "short" });
+
+  for (let month = 0; month < 12; month += 1) {
+    const date = new Date(Date.UTC(2021, month, 1));
+    monthNames.push(longMonthFormatter.format(date));
+    monthNamesShort.push(shortMonthFormatter.format(date));
+  }
+
+  return {
+    dayNames,
+    dayNamesShort,
+    dayNamesMin,
+    monthNames,
+    monthNamesShort,
+    firstDayOfWeek: weekStartsOn ?? defaultWeekStart ?? 0,
+  };
+}
+
+export function getLocaleRegistrationKeys(locale: string): string[] {
+  const keys = new Set<string>();
+  if (locale) {
+    keys.add(locale);
+    keys.add(locale.replace(/_/g, "-"));
+    keys.add(locale.toLowerCase());
+    keys.add(locale.replace(/_/g, "-").toLowerCase());
+  }
+  return Array.from(keys);
+}
+
+export function registerCalendarLocale(
+  locale: string,
+  options: ReturnType<typeof buildCalendarLocaleOptions>,
+  fallbackOptions: ReturnType<typeof buildCalendarLocaleOptions>,
+): string {
+  const keys = getLocaleRegistrationKeys(locale);
+  keys.forEach((key) => addLocale(key, options));
+  addLocale(FALLBACK_LOCALE, fallbackOptions);
+  return keys[0] ?? locale ?? FALLBACK_LOCALE;
+}
+

--- a/test/calendarLocale.test.ts
+++ b/test/calendarLocale.test.ts
@@ -1,0 +1,27 @@
+jest.mock("primereact/api", () => ({ addLocale: jest.fn() }));
+
+import { buildCalendarLocaleOptions, normalizeLocaleTag } from "../src/utils/calendarLocale";
+
+describe("calendar locale utilities", () => {
+  it("normalizes locales and always provides firstDayOfWeek", () => {
+    const locales = ["en-us", "en", "en-AU", "fr-FR", "es-419", "ar-SA", "ja-JP", "invalid-locale"];
+    for (const raw of locales) {
+      const normalized = normalizeLocaleTag(raw);
+      const options = buildCalendarLocaleOptions(normalized, undefined, 3);
+      expect(typeof options.firstDayOfWeek).toBe("number");
+      expect(options.firstDayOfWeek).toBeGreaterThanOrEqual(0);
+      expect(options.firstDayOfWeek).toBeLessThan(7);
+    }
+  });
+
+  it("respects explicit week start overrides", () => {
+    const normalized = normalizeLocaleTag("de-DE");
+    const options = buildCalendarLocaleOptions(normalized, 4, undefined);
+    expect(options.firstDayOfWeek).toBe(4);
+  });
+
+  it("falls back to the default locale when Intl cannot resolve a tag", () => {
+    const normalized = normalizeLocaleTag("no_such_locale");
+    expect(normalized).toBe("en");
+  });
+});

--- a/test/mocks/primereact/api.ts
+++ b/test/mocks/primereact/api.ts
@@ -1,0 +1,3 @@
+export const addLocale = () => {
+  // noop mock used during tests
+};

--- a/test/mocks/primereact/calendar.tsx
+++ b/test/mocks/primereact/calendar.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export type CalendarPassThroughOptions = Record<string, unknown>;
+
+export const Calendar = React.forwardRef<HTMLDivElement, Record<string, unknown>>((props, ref) => (
+  <div ref={ref} data-mock="primereact-calendar" {...props} />
+));
+
+Calendar.displayName = "MockPrimeCalendar";
+
+export default Calendar;

--- a/test/mocks/primereact/ts-helpers.ts
+++ b/test/mocks/primereact/ts-helpers.ts
@@ -1,0 +1,1 @@
+export type FormEvent<T> = { value?: T };


### PR DESCRIPTION
## Summary
- normalize and register PrimeReact calendar locales up front so `firstDayOfWeek` is always defined
- add inert-based focus management for the popover/dialog and switch focus trapping to useLayoutEffect
- provide Jest stubs and locale utilities plus documentation notes for new behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68f07d13ae688321a7722615717cab04